### PR TITLE
Pos orders fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-- "2.3.1"
+- "2.3.4"
 
 gemfile:
   - Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '2.3.4'
 
 gem 'rake'
 gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ DEPENDENCIES
   wkhtmltopdf-heroku
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.4p301
 
 BUNDLED WITH
-   1.13.6
+   1.15.3

--- a/app/utils.rb/render_pdf.rb
+++ b/app/utils.rb/render_pdf.rb
@@ -1,0 +1,19 @@
+require 'tilt/liquid'
+require 'wicked_pdf'
+
+def render_pdf(shop, order, charity, donation_amount)
+  order['created_at'] = Time.parse(order['created_at']).strftime("%B %d, %Y")
+  order['billing_address'] ||= order['customer']['default_address']
+
+  template = Tilt::LiquidTemplate.new { |t| charity.pdf_template }
+  pdf_content = template.render(
+    shop: shop.attributes,
+    order: order,
+    charity: charity,
+    donation_amount: donation_amount
+  )
+
+  WickedPdf.new.pdf_from_string(
+    Tilt::ERBTemplate.new('views/receipt/pdf.erb').render(Object.new, pdf_content: pdf_content)
+  )
+end

--- a/app/utils/render_pdf.rb
+++ b/app/utils/render_pdf.rb
@@ -1,0 +1,19 @@
+require 'tilt/liquid'
+require 'wicked_pdf'
+
+def render_pdf(shop, order, charity, donation_amount)
+  order['created_at'] = Time.parse(order['created_at']).strftime("%B %d, %Y")
+  order['billing_address'] ||= order['customer']['default_address']
+
+  template = Tilt::LiquidTemplate.new { |t| charity.pdf_template }
+  pdf_content = template.render(
+    shop: shop.attributes,
+    order: order,
+    charity: charity,
+    donation_amount: donation_amount
+  )
+
+  WickedPdf.new.pdf_from_string(
+    Tilt::ERBTemplate.new('views/receipt/pdf.erb').render(Object.new, pdf_content: pdf_content)
+  )
+end

--- a/test/fixtures/order_customer_address.json
+++ b/test/fixtures/order_customer_address.json
@@ -1,0 +1,261 @@
+{
+  "buyer_accepts_marketing": false,
+  "cancel_reason": null,
+  "cancelled_at": null,
+  "cart_token": "68778783ad298f1c80c3bafcddeea02f",
+  "checkout_token": null,
+  "closed_at": null,
+  "confirmed": false,
+  "created_at": "2008-01-10T11:00:00-05:00",
+  "currency": "USD",
+  "email": "bob.norman@hostmail.com",
+  "financial_status": "authorized",
+  "fulfillment_status": null,
+  "gateway": "authorize_net",
+  "id": 450789469,
+  "landing_site": "http://www.example.com?source=abc",
+  "location_id": null,
+  "name": "#1001",
+  "note": "Test note",
+  "number": 1,
+  "reference": "fhwdgads",
+  "referring_site": "http://www.otherexample.com",
+  "source": null,
+  "source_identifier": "fhwdgads",
+  "source_name": "web",
+  "source_url": null,
+  "subtotal_price": "398.00",
+  "taxes_included": false,
+  "test": false,
+  "token": "b1946ac92492d2347c6235b4d2611184",
+  "total_discounts": "0.00",
+  "total_line_items_price": "398.00",
+  "total_price": "409.94",
+  "total_price_usd": "409.94",
+  "total_tax": "11.94",
+  "total_weight": 0,
+  "updated_at": "2008-01-10T11:00:00-05:00",
+  "user_id": null,
+  "browser_ip": null,
+  "landing_site_ref": "abc",
+  "order_number": 1001,
+  "discount_codes": [
+    {
+      "code": "TENOFF",
+      "amount": "10.00"
+    }
+  ],
+  "note_attributes": [
+    {
+      "name": "custom engraving",
+      "value": "Happy Birthday"
+    },
+    {
+      "name": "colour",
+      "value": "green"
+    }
+  ],
+  "processing_method": "direct",
+  "checkout_id": 450789469,
+  "tax_lines": [
+    {
+      "price": "11.94",
+      "rate": 0.06,
+      "title": "State Tax"
+    }
+  ],
+  "tags": "",
+  "line_items": [
+    {
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "grams": 200,
+      "id": 466157049,
+      "price": "199.00",
+      "product_id": 632910392,
+      "quantity": 1,
+      "requires_shipping": true,
+      "sku": "IPOD2008GREEN",
+      "taxable": true,
+      "title": "IPod Nano - 8gb",
+      "variant_id": 39072856,
+      "variant_title": "green",
+      "vendor": null,
+      "name": "IPod Nano - 8gb - green",
+      "variant_inventory_management": "shopify",
+      "properties": [
+        {
+          "name": "Custom Engraving",
+          "value": "Happy Birthday"
+        }
+      ],
+      "product_exists": true,
+      "tax_lines": [
+
+      ]
+    },
+    {
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "grams": 200,
+      "id": 518995019,
+      "price": "199.00",
+      "product_id": 632910392,
+      "quantity": 1,
+      "requires_shipping": true,
+      "sku": "IPOD2008RED",
+      "taxable": true,
+      "title": "IPod Nano - 8gb",
+      "variant_id": 49148385,
+      "variant_title": "red",
+      "vendor": null,
+      "name": "IPod Nano - 8gb - red",
+      "variant_inventory_management": "shopify",
+      "properties": [
+
+      ],
+      "product_exists": true,
+      "tax_lines": [
+
+      ]
+    },
+    {
+      "fulfillment_service": "manual",
+      "fulfillment_status": null,
+      "grams": 200,
+      "id": 703073504,
+      "price": "199.00",
+      "product_id": 632910392,
+      "quantity": 1,
+      "requires_shipping": true,
+      "sku": "IPOD2008BLACK",
+      "taxable": true,
+      "title": "IPod Nano - 8gb",
+      "variant_id": 457924702,
+      "variant_title": "black",
+      "vendor": null,
+      "name": "IPod Nano - 8gb - black",
+      "variant_inventory_management": "shopify",
+      "properties": [
+
+      ],
+      "product_exists": true,
+      "tax_lines": [
+
+      ]
+    }
+  ],
+  "shipping_lines": [
+    {
+      "code": "Free Shipping",
+      "price": "0.00",
+      "source": "shopify",
+      "title": "Free Shipping",
+      "tax_lines": [
+
+      ]
+    }
+  ],
+  "payment_details": {
+    "avs_result_code": null,
+    "credit_card_bin": null,
+    "cvv_result_code": null,
+    "credit_card_number": "XXXX-XXXX-XXXX-4242",
+    "credit_card_company": "Visa"
+  },
+  "fulfillments": [
+    {
+      "created_at": "2014-03-07T16:14:08-05:00",
+      "id": 255858046,
+      "order_id": 450789469,
+      "service": "manual",
+      "status": "failure",
+      "tracking_company": null,
+      "updated_at": "2014-03-07T16:14:08-05:00",
+      "tracking_number": "1Z2345",
+      "tracking_numbers": [
+        "1Z2345"
+      ],
+      "tracking_url": "http://wwwapps.ups.com/etracking/tracking.cgi?InquiryNumber1=1Z2345&TypeOfInquiryNumber=T&AcceptUPSLicenseAgreement=yes&submit=Track",
+      "tracking_urls": [
+        "http://wwwapps.ups.com/etracking/tracking.cgi?InquiryNumber1=1Z2345&TypeOfInquiryNumber=T&AcceptUPSLicenseAgreement=yes&submit=Track"
+      ],
+      "receipt": {
+        "testcase": true,
+        "authorization": "123456"
+      },
+      "line_items": [
+        {
+          "fulfillment_service": "manual",
+          "fulfillment_status": null,
+          "grams": 200,
+          "id": 466157049,
+          "price": "199.00",
+          "product_id": 632910392,
+          "quantity": 1,
+          "requires_shipping": true,
+          "sku": "IPOD2008GREEN",
+          "taxable": true,
+          "title": "IPod Nano - 8gb",
+          "variant_id": 39072856,
+          "variant_title": "green",
+          "vendor": null,
+          "name": "IPod Nano - 8gb - green",
+          "variant_inventory_management": "shopify",
+          "properties": [
+            {
+              "name": "Custom Engraving",
+              "value": "Happy Birthday"
+            }
+          ],
+          "product_exists": true,
+          "tax_lines": [
+
+          ]
+        }
+      ]
+    }
+  ],
+  "client_details": {
+    "accept_language": null,
+    "browser_ip": "0.0.0.0",
+    "session_hash": null,
+    "user_agent": null
+  },
+  "customer": {
+    "accepts_marketing": false,
+    "created_at": "2014-03-07T16:14:08-05:00",
+    "email": "bob.norman@hostmail.com",
+    "first_name": "Bob",
+    "id": 207119551,
+    "last_name": "Norman",
+    "last_order_id": null,
+    "multipass_identifier": null,
+    "note": null,
+    "orders_count": 0,
+    "state": "disabled",
+    "total_spent": "0.00",
+    "updated_at": "2014-03-07T16:14:08-05:00",
+    "verified_email": true,
+    "tags": "",
+    "last_order_name": null,
+    "default_address": {
+      "address1": "Chestnut Street 92",
+      "address2": "",
+      "city": "Louisville",
+      "company": null,
+      "country": "United States",
+      "first_name": null,
+      "id": 207119551,
+      "last_name": null,
+      "phone": "555-625-1199",
+      "province": "Kentucky",
+      "zip": "40202",
+      "name": null,
+      "province_code": "KY",
+      "country_code": "US",
+      "country_name": "United States",
+      "default": true
+    }
+  }
+}

--- a/test/render_pdf_test.rb
+++ b/test/render_pdf_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require_relative '../app/utils/render_pdf'
 
 class RenderPdfTest < ActiveSupport::TestCase
 
@@ -20,6 +21,11 @@ class RenderPdfTest < ActiveSupport::TestCase
     pdf = render_pdf(@shop, order, @charity, 20)
   end
 
+  test "order_no_billing_address_uses_customer_default_address" do
+    order = JSON.parse(load_fixture('order_customer_address.json'))
+    pdf = render_pdf(@shop, order, @charity, 20)
+  end
+
   test "order_no_zip" do
     order = JSON.parse(load_fixture('order_no_zip.json'))
     pdf = render_pdf(@shop, order, @charity, 20)
@@ -32,22 +38,6 @@ class RenderPdfTest < ActiveSupport::TestCase
   end
 
   private
-
-  def render_pdf(shop, order, charity, donation_amount)
-    order['created_at'] = Time.parse(order['created_at']).strftime("%B %d, %Y")
-
-    template = Tilt::LiquidTemplate.new { |t| charity.pdf_template }
-    pdf_content = template.render(
-      shop: shop.attributes,
-      order: order,
-      charity: charity,
-      donation_amount: donation_amount
-    )
-
-    WickedPdf.new.pdf_from_string(
-      Tilt::ERBTemplate.new('views/receipt/pdf.erb').render(Object.new, pdf_content: pdf_content)
-    )
-  end
 
   def write_pdf(pdf_string)
     File.open('test.pdf', 'w') { |file| file.write(pdf_string) }

--- a/views/receipt/email.liquid
+++ b/views/receipt/email.liquid
@@ -1,4 +1,4 @@
-Dear {{ order['billing_address']['first_name'] }} {{ order['billing_address']['last_name'] }},
+Dear {{ order['customer']['first_name'] }} {{ order['customer']['last_name'] }},
 
 On behalf of {{ charity['name'] }}, we would like to thank you from the bottom of our hearts for your contribution to our cause. It may seem like a small gesture to you, but to us, it’s what we thrive on. Feel free to share the word to your friends and family as well!
 


### PR DESCRIPTION
POS orders appear to not have a billing address the way web orders do. They do still have a customer default address though. This PR makes 2 changes:

* use `customer` `first_name` and `last_name` instead of `billing_address` `first_name` and `last_name` in the email template
* For the pdf fall back to customer default address if there is no billing address
* In light of these changes I removed a check that enforced the requirement of the billing address