### PR TITLE
Donations view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ gem 'foreman'
 
 gem 'shopify-sinatra-app', '~> 0.4.0'
 gem 'sinatra-contrib'
-gem 'kaminari-sinatra'
+
+gem 'kaminari-sinatra', git: 'https://github.com/kevinhughes27/kaminari-sinatra', ref: '2e7eb2771f921eaf75aab9dd21bf465876be3404'
 gem 'kaminari-activerecord'
 
 gem 'wicked_pdf'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ gem 'foreman'
 
 gem 'shopify-sinatra-app', '~> 0.4.0'
 gem 'sinatra-contrib'
-gem 'sinatra-partial'
+gem 'kaminari-sinatra'
+gem 'kaminari-activerecord'
 
 gem 'wicked_pdf'
 gem 'pony'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    actionview (5.1.5)
+      activesupport (= 5.1.5)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
     activemodel (5.1.5)
       activesupport (= 5.1.5)
     activemodel-serializers-xml (1.0.2)
@@ -25,12 +31,14 @@ GEM
     arel (8.0.0)
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
-    backports (3.11.1)
+    backports (3.11.3)
     builder (3.2.3)
     byebug (10.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    crass (1.0.4)
     encryptor (3.0.0)
+    erubi (1.7.1)
     fakeweb (1.3.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -43,16 +51,29 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     jwt (1.5.6)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
+    kaminari-sinatra (1.0.1)
+      actionview
+      kaminari-core (~> 1.0)
+      padrino-helpers
+      sinatra
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.6.0)
       launchy (~> 2.2)
     liquid (4.0.0)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     metaclass (0.0.4)
     method_source (0.9.0)
     mini_mime (1.0.0)
+    mini_portile2 (2.3.0)
     minitest (5.11.3)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
@@ -61,6 +82,8 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustermann (1.0.2)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
@@ -75,6 +98,11 @@ GEM
       omniauth (~> 1.2)
     omniauth-shopify-oauth2 (1.2.1)
       omniauth-oauth2 (~> 1.5.0)
+    padrino-helpers (0.14.3)
+      i18n (~> 0.6, >= 0.6.7)
+      padrino-support (= 0.14.3)
+      tilt (>= 1.4.1, < 3)
+    padrino-support (0.14.3)
     pg (1.0.0)
     pony (1.12)
       mail (>= 2.0)
@@ -89,6 +117,11 @@ GEM
       rack
     rack-test (0.8.3)
       rack (>= 1.0, < 3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     rake (12.3.0)
     raygun4ruby (2.7.0)
       concurrent-ruby
@@ -132,8 +165,6 @@ GEM
       rack-protection (= 2.0.1)
       sinatra (= 2.0.1)
       tilt (>= 1.3, < 3)
-    sinatra-partial (1.0.1)
-      sinatra (>= 1.4)
     sinatra-redis (0.3.0)
       redis
       sinatra (>= 0.9.4)
@@ -156,6 +187,8 @@ DEPENDENCIES
   byebug
   fakeweb
   foreman
+  kaminari-activerecord
+  kaminari-sinatra
   letter_opener
   liquid
   mocha
@@ -167,7 +200,6 @@ DEPENDENCIES
   raygun4ruby
   shopify-sinatra-app (~> 0.4.0)
   sinatra-contrib
-  sinatra-partial
   sqlite3
   wicked_pdf
   wkhtmltopdf-binary

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/kevinhughes27/kaminari-sinatra
+  revision: 2e7eb2771f921eaf75aab9dd21bf465876be3404
+  ref: 2e7eb2771f921eaf75aab9dd21bf465876be3404
+  specs:
+    kaminari-sinatra (1.0.1)
+      actionview
+      kaminari-core (~> 1.0)
+      padrino-helpers
+      sinatra
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -55,11 +66,6 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
-    kaminari-sinatra (1.0.1)
-      actionview
-      kaminari-core (~> 1.0)
-      padrino-helpers
-      sinatra
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.6.0)
@@ -188,7 +194,7 @@ DEPENDENCIES
   fakeweb
   foreman
   kaminari-activerecord
-  kaminari-sinatra
+  kaminari-sinatra!
   letter_opener
   liquid
   mocha

--- a/config/pagination.rb
+++ b/config/pagination.rb
@@ -1,2 +1,6 @@
 require 'kaminari/sinatra'
 require 'kaminari/activerecord'
+
+Kaminari.configure do |config|
+  config.params_on_first_page = true
+end

--- a/config/pagination.rb
+++ b/config/pagination.rb
@@ -1,0 +1,2 @@
+require 'kaminari/sinatra'
+require 'kaminari/activerecord'

--- a/src/app.rb
+++ b/src/app.rb
@@ -28,6 +28,15 @@ class SinatraApp < Sinatra::Base
       @charity = Charity.find_by(shop: current_shop_name)
       @products = Product.where(shop: current_shop_name).page(params[:products_page])
       @donations = Donation.where(shop: current_shop_name).page(params[:donations_page])
+
+      @tab = if params[:products_page]
+        'products'
+      elsif params[:donations_page]
+        'donations'
+      else
+        'products'
+      end
+
       erb :home
     end
   end

--- a/src/app.rb
+++ b/src/app.rb
@@ -26,7 +26,7 @@ class SinatraApp < Sinatra::Base
     shopify_session do
       @shop = ShopifyAPI::Shop.current
       @charity = Charity.find_by(shop: current_shop_name)
-      @products = Product.where(shop: current_shop_name)
+      @products = Product.where(shop: current_shop_name).page(params[:products_page])
       @donations = Donation.where(shop: current_shop_name).page(params[:donations_page])
       erb :home
     end

--- a/src/app.rb
+++ b/src/app.rb
@@ -28,15 +28,7 @@ class SinatraApp < Sinatra::Base
       @charity = Charity.find_by(shop: current_shop_name)
       @products = Product.where(shop: current_shop_name).page(params[:products_page])
       @donations = Donation.where(shop: current_shop_name).page(params[:donations_page])
-
-      @tab = if params[:products_page]
-        'products'
-      elsif params[:donations_page]
-        'donations'
-      else
-        'products'
-      end
-
+      @tab = params[:tab] || 'products'
       erb :home
     end
   end

--- a/src/app.rb
+++ b/src/app.rb
@@ -32,6 +32,7 @@ class SinatraApp < Sinatra::Base
       @shop = ShopifyAPI::Shop.current
       @charity = Charity.find_by(shop: current_shop_name)
       @products = Product.where(shop: current_shop_name)
+      @donations = Donation.where(shop: current_shop_name)
       erb :home
     end
   end

--- a/src/app.rb
+++ b/src/app.rb
@@ -1,10 +1,9 @@
 require 'sinatra/shopify-sinatra-app'
-require 'sinatra/content_for'
-require 'sinatra/partial'
 
 require_relative '../config/pony'
 require_relative '../config/pdf_engine'
 require_relative '../config/exception_tracker'
+require_relative '../config/pagination'
 require_relative '../config/development' if ENV['DEVELOPMENT']
 
 require_relative 'concerns/install'
@@ -20,11 +19,7 @@ class SinatraApp < Sinatra::Base
   register Sinatra::Shopify
   set :scope, 'read_products, read_orders'
 
-  register Sinatra::Partial
-  set :partial_template_engine, :erb
-  enable :partial_underscores
-
-  helpers Sinatra::ContentFor
+  register Kaminari::Helpers::SinatraHelpers
 
   # Home page
   get '/' do
@@ -32,7 +27,7 @@ class SinatraApp < Sinatra::Base
       @shop = ShopifyAPI::Shop.current
       @charity = Charity.find_by(shop: current_shop_name)
       @products = Product.where(shop: current_shop_name)
-      @donations = Donation.where(shop: current_shop_name)
+      @donations = Donation.where(shop: current_shop_name).page(params[:donations_page])
       erb :home
     end
   end

--- a/src/utils/render_pdf.rb
+++ b/src/utils/render_pdf.rb
@@ -1,4 +1,25 @@
 require 'tilt/liquid'
+
+module Rails
+  def self.env
+    'production'
+  end
+
+  module VERSION
+    MAJOR = 0
+  end
+end
+
+class WickedPdf
+  class Mime
+    class Type
+      def self.lookup_by_extension(var)
+        true
+      end
+    end
+  end
+end
+
 require 'wicked_pdf'
 
 def render_pdf(shop, order, charity, donation_amount)

--- a/views/_donations.erb
+++ b/views/_donations.erb
@@ -1,0 +1,23 @@
+<% if donations.present? %>
+  <table class="table table-striped table-hover">
+    <tbody>
+      <tr>
+        <th>Order ID</th>
+        <th>Date</th>
+        <th>Amount</th>
+      </tr>
+
+      <% donations.each do |donation| %>
+        <tr>
+          <td>
+            <a href=<%="#{current_shop_url}/admin/orders/#{donation.order_id}"%> target="_blank"> <%= donation.order_id %></a>
+          </td>
+          <td><%= donation.created_at %></td>
+          <td><%= donation.donation_amount %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>No donations have been sent yet</p>
+<% end %>

--- a/views/_donations.erb
+++ b/views/_donations.erb
@@ -20,7 +20,7 @@
   </table>
 
   <div style="padding-left: 5px;">
-    <%= paginate donations, param_name: :donations_page %>
+    <%= paginate donations, param_name: :donations_page, params: {tab: 'donations'} %>
   </div>
 <% else %>
   <p>No donations have been sent yet</p>

--- a/views/_donations.erb
+++ b/views/_donations.erb
@@ -18,6 +18,10 @@
       <% end %>
     </tbody>
   </table>
+
+  <div style="padding-left: 5px;">
+    <%= paginate donations, param_name: :donations_page %>
+  </div>
 <% else %>
   <p>No donations have been sent yet</p>
 <% end %>

--- a/views/_products.erb
+++ b/views/_products.erb
@@ -1,7 +1,4 @@
-<h3>Products</h3>
-
-<% if @products.present? %>
-  <p>Make sure you aren't charging taxes or shipping for any of these products!</p>
+<% if products.present? %>
   <table class="table table-striped table-hover">
     <tbody>
       <tr>
@@ -11,10 +8,10 @@
         <th></th>
       </tr>
 
-      <% @products.each do |product| %>
+      <% products.each do |product| %>
         <tr>
           <td>
-            <a href=<%="#{current_shop_url}/admin/products/#{product.product_id}"%> target="_blank"> <%= product.product_id %> </a>
+            <a href=<%="#{current_shop_url}/admin/products/#{product.product_id}"%> target="_blank"> <%= product.product_id %></a>
           </td>
 
           <form method="POST" action="/products">
@@ -51,5 +48,5 @@
     </tbody>
   </table>
 <% else %>
-  <p> No products are currently setup for tax receipts. Visit the <a href="/help">help page</a> to see how to get started!</p>
+  <p>No products are currently setup for tax receipts. Visit the <a href="/help">help page</a> to see how to get started!</p>
 <% end %>

--- a/views/_products.erb
+++ b/views/_products.erb
@@ -49,7 +49,7 @@
   </table>
 
   <div style="padding-left: 5px;">
-    <%= paginate products, param_name: :products_page %>
+    <%= paginate products, param_name: :products_page, params: {tab: 'products'} %>
   </div>
 <% else %>
   <p>No products are currently setup for tax receipts. Visit the <a href="/help">help page</a> to see how to get started!</p>

--- a/views/_products.erb
+++ b/views/_products.erb
@@ -47,6 +47,10 @@
       <% end %>
     </tbody>
   </table>
+
+  <div style="padding-left: 5px;">
+    <%= paginate products, param_name: :products_page %>
+  </div>
 <% else %>
   <p>No products are currently setup for tax receipts. Visit the <a href="/help">help page</a> to see how to get started!</p>
 <% end %>

--- a/views/_tabs.erb
+++ b/views/_tabs.erb
@@ -1,0 +1,26 @@
+<ul class="nav nav-tabs" id="tabs">
+  <li class="active">
+    <a href="#products">Products</a>
+  </li>
+  <li>
+    <a href="#donations">Donations</a>
+  </li>
+</ul>
+
+<div class="tab-content">
+  <div class="tab-pane active" id="products">
+    <br>
+    <%= partial 'products', locals: {products: products} %>
+  </div>
+  <div class="tab-pane" id="donations">
+    <br>
+    <%= partial 'donations', locals: {donations: donations} %>
+  </div>
+</div>
+
+<script>
+  $('#tabs a').click(function (e) {
+    e.preventDefault();
+    $(this).tab('show');
+  })
+</script>

--- a/views/_tabs.erb
+++ b/views/_tabs.erb
@@ -1,18 +1,18 @@
 <ul class="nav nav-tabs" id="tabs">
-  <li class="active">
+  <li class="<%= 'active' if tab == 'products' %>">
     <a href="#products">Products</a>
   </li>
-  <li>
+  <li class="<%= 'active' if tab == 'donations' %>">
     <a href="#donations">Donations</a>
   </li>
 </ul>
 
 <div class="tab-content">
-  <div class="tab-pane active" id="products">
+  <div class="tab-pane <%= 'active' if tab == 'products' %>" id="products">
     <br>
     <%= partial 'products', locals: {products: products} %>
   </div>
-  <div class="tab-pane" id="donations">
+  <div class="tab-pane <%= 'active' if tab == 'donations' %>" id="donations">
     <br>
     <%= partial 'donations', locals: {donations: donations} %>
   </div>

--- a/views/home.erb
+++ b/views/home.erb
@@ -20,7 +20,7 @@
 </div>
 
 <% if @charity.present? %>
-  <%= partial 'products', locals: {products: @products} %>
+  <%= partial 'tabs', locals: {products: @products, donations: @donations} %>
 <% end %>
 
 <% content_for :footer do %>

--- a/views/home.erb
+++ b/views/home.erb
@@ -20,7 +20,7 @@
 </div>
 
 <% if @charity.present? %>
-  <%= partial 'tabs', locals: {products: @products, donations: @donations} %>
+  <%= partial 'tabs', locals: {tab: @tab, products: @products, donations: @donations} %>
 <% end %>
 
 <% content_for :footer do %>


### PR DESCRIPTION
This PR adds a donations view. The UI is updated to have tabs for both products and donations.

![image](https://user-images.githubusercontent.com/1965489/39061161-6b0c2bfc-4491-11e8-9a72-459bd0109f3c.png)

I added pagination (for both products and donations) since it will be required for donations. I did this via `kaminari-sinatra` which adds the `padrino-helpers` gem (padrino is a framework built on top of sinatra which adds a lot the things most people use all the time). This caused some issues at first which I tracked down to `padrino-helpers` adding `partials` and `content_for` which I had manually added from `sinatra-contrib` and elsewhere. I was able to remove these extras and just rely on the padrino helpers.

The kaminari include also brought in `action-view` which caused issued with [wicked-pdf](https://github.com/mileszs/wicked_pdf) since it detected `Rails.env` and started trying to do some Rails specific things. I fixed this with an ugly override for now. I should follow up with `wicked-pdf` about their Rails detection.