### PR TITLE
Resend

### DIFF
--- a/src/app.rb
+++ b/src/app.rb
@@ -64,6 +64,25 @@ class SinatraApp < Sinatra::Base
     end
   end
 
+  # resend a donation receipt
+  post '/resend' do
+    shopify_session do
+      donation = Donation.find_by(id: params['id'])
+
+      charity = Charity.find_by(shop: current_shop_name)
+      shopify_shop = ShopifyAPI::Shop.current
+
+      order = JSON.parse(donation.order.to_json)
+      donation_amount = donation.donation_amount
+
+      receipt_pdf = render_pdf(shopify_shop, order, charity, donation_amount)
+      deliver_donation_receipt(shopify_shop, order, charity, receipt_pdf)
+
+      flash[:notice] = "Email resent!"
+      redirect '/'
+    end
+  end
+
   # render a preview of user edited email template
   get '/preview_email' do
     shopify_session do
@@ -76,6 +95,7 @@ class SinatraApp < Sinatra::Base
     end
   end
 
+  # render a preview of the user edited pdf template
   get '/preview_pdf' do
     shopify_session do
       charity = Charity.find_by(shop: current_shop_name)

--- a/views/_donations.erb
+++ b/views/_donations.erb
@@ -5,6 +5,7 @@
         <th>Order ID</th>
         <th>Date</th>
         <th>Amount</th>
+        <th></th>
       </tr>
 
       <% donations.each do |donation| %>
@@ -14,6 +15,13 @@
           </td>
           <td><%= donation.created_at %></td>
           <td><%= donation.donation_amount %></td>
+
+          <form method="POST" action="/resend">
+            <td style="width:1px;">
+              <input type="hidden" name="id" value="<%= donation.id %>" />
+              <input type="submit" class="btn btn-default align-right" value="resend">
+            </td>
+          </form>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
Adds the ability to resend a donation receipt from the donations tab. The workflow requires the user to know the order_id so they can find it in the list and hit re-send. This should be okay for the low volume donation situations the app is intended for.

![image](https://user-images.githubusercontent.com/1965489/39400288-cf1ce8aa-4afb-11e8-9542-20a61a3eeb15.png)
