### PR TITLE
pass donation model into templates

### DIFF
--- a/src/app.rb
+++ b/src/app.rb
@@ -145,9 +145,7 @@ class SinatraApp < Sinatra::Base
   private
 
   def deliver_donation_receipt(shop, order, charity, donation, pdf, to = nil)
-    return unless order["customer"]
-    return unless to ||= order["customer"]["email"]
-
+    to ||= order["customer"]["email"]
     bcc = charity.email_bcc
     from = charity.email_from || shop.email
     subject = charity.email_subject

--- a/src/app.rb
+++ b/src/app.rb
@@ -42,6 +42,9 @@ class SinatraApp < Sinatra::Base
   # order/create webhook receiver
   post '/order.json' do
     webhook_session do |order|
+      return unless order['customer']
+      return unless order['customer']['email']
+
       donation_products = Product.where(shop: current_shop_name)
 
       donations = []

--- a/src/app.rb
+++ b/src/app.rb
@@ -145,6 +145,7 @@ class SinatraApp < Sinatra::Base
   def save_donation(shop_name, order, donation_amount)
     donation = Donation.new(shop: shop_name, order_id: order['id'], donation_amount: donation_amount)
     donation.save!
+    donation.order = ShopifyAPI::Order.new(order)
     donation
   rescue ActiveRecord::RecordInvalid => e
     raise unless e.message == 'Validation failed: Order has already been taken'
@@ -175,7 +176,7 @@ class SinatraApp < Sinatra::Base
 
   def mock_donation
     donation = Donation.new(shop: current_shop_name, order_id: mock_order['id'], donation_amount: 20.00)
-    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(mock_order))
+    donation.order = ShopifyAPI::Order.new(mock_order)
     donation
   end
 

--- a/src/models/charity.rb
+++ b/src/models/charity.rb
@@ -31,6 +31,9 @@ class Charity < ActiveRecord::Base
   end
 
   def to_liquid
-    attributes
+    {
+      'name' => name,
+      'charity_id' => charity_id
+    }
   end
 end

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -2,20 +2,56 @@ class Donation < ActiveRecord::Base
   validates_presence_of :shop, :order_id, :donation_amount
   validates_uniqueness_of :order_id, scope: :shop
 
-  delegate :order_number,
-           :first_name,
-           :last_name,
-           :address1,
+  delegate :address1,
            :city,
            :country,
            :zip,
-           to: :order
+           to: :address
+
+  def order=(shopify_order)
+    @order = shopify_order
+  end
 
   def order
     @order ||= ShopifyAPI::Order.find(order_id)
   end
 
+  def address
+    order.billing_address || order.attributes.dig('default_address')
+  end
+
+  def order_number
+    order.number
+  end
+
+  def email
+    order.customer.email
+  end
+
+  def first_name
+    address.first_name
+  end
+
+  def last_name
+    address.last_name
+  end
+
   def donation_amount
     sprintf( "%0.02f", read_attribute(:donation_amount))
+  end
+
+  def to_liquid
+    {
+      'order_number' => order_number,
+      'email' => email,
+      'first_name' => first_name,
+      'last_name' => last_name,
+      'address1' => address1,
+      'city' => city,
+      'country' => country,
+      'zip' => zip,
+      'created_at' => created_at,
+      'donation_amount' => donation_amount
+    }
   end
 end

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -14,4 +14,8 @@ class Donation < ActiveRecord::Base
   def order
     @order ||= ShopifyAPI::Order.find(order_id)
   end
+
+  def donation_amount
+    sprintf( "%0.02f", read_attribute(:donation_amount))
+  end
 end

--- a/src/utils/donation_service.rb
+++ b/src/utils/donation_service.rb
@@ -1,0 +1,14 @@
+def build_donation(shop_name, order, donation_amount)
+  donation = Donation.new(shop: shop_name, order_id: order['id'], donation_amount: donation_amount)
+  donation.order = ShopifyAPI::Order.new(order)
+  donation
+end
+
+def save_donation(shop_name, order, donation_amount)
+  donation = build_donation(shop_name, order, donation_amount)
+  donation.save!
+  donation
+rescue ActiveRecord::RecordInvalid => e
+  raise unless e.message == 'Validation failed: Order has already been taken'
+  false
+end

--- a/src/utils/render_pdf.rb
+++ b/src/utils/render_pdf.rb
@@ -22,7 +22,7 @@ end
 
 require 'wicked_pdf'
 
-def render_pdf(shop, order, charity, donation_amount)
+def render_pdf(shop, order, charity, donation)
   order['created_at'] = Time.parse(order['created_at']).strftime("%B %d, %Y")
   order['billing_address'] ||= order.dig('default_address')
 
@@ -31,7 +31,8 @@ def render_pdf(shop, order, charity, donation_amount)
     shop: shop.attributes,
     order: order,
     charity: charity,
-    donation_amount: donation_amount
+    donation: donation,
+    donation_amount: donation.donation_amount
   )
 
   WickedPdf.new.pdf_from_string(

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -37,6 +37,34 @@ class AppTest < ActiveSupport::TestCase
     assert last_response.ok?
   end
 
+  test "order with no email" do
+    order_webhook = JSON.parse(load_fixture('order_webhook.json'))
+    order_webhook['customer'].delete('email')
+    order_webhook = order_webhook.to_json
+
+    SinatraApp.any_instance.expects(:verify_shopify_webhook).returns(true)
+    fake "https://apple.myshopify.com/admin/shop.json", :body => load_fixture('shop.json')
+
+    Pony.expects(:mail).never
+
+    post '/order.json', order_webhook, 'HTTP_X_SHOPIFY_SHOP_DOMAIN' => @shop
+    assert last_response.ok?
+  end
+
+  test "order with no customer" do
+    order_webhook = JSON.parse(load_fixture('order_webhook.json'))
+    order_webhook.delete('customer')
+    order_webhook = order_webhook.to_json
+
+    SinatraApp.any_instance.expects(:verify_shopify_webhook).returns(true)
+    fake "https://apple.myshopify.com/admin/shop.json", :body => load_fixture('shop.json')
+
+    Pony.expects(:mail).never
+
+    post '/order.json', order_webhook, 'HTTP_X_SHOPIFY_SHOP_DOMAIN' => @shop
+    assert last_response.ok?
+  end
+
   test "order_endpoint_with_product_percentage" do
     product = Product.find_by(shop: @shop)
     product.update_attribute(:percentage, 80)

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -46,8 +46,8 @@ class AppTest < ActiveSupport::TestCase
     SinatraApp.any_instance.expects(:verify_shopify_webhook).returns(true)
     fake "https://apple.myshopify.com/admin/shop.json", :body => load_fixture('shop.json')
 
-    SinatraApp.any_instance.expects(:render_pdf).with do |shop, order, charity, donation_amount|
-      assert_equal '477.60', donation_amount
+    SinatraApp.any_instance.expects(:render_pdf).with do |shop, order, charity, donation|
+      assert_equal '477.60', donation.donation_amount.to_s
     end
 
     Pony.expects(:mail).once

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -75,7 +75,7 @@ class AppTest < ActiveSupport::TestCase
     fake "https://apple.myshopify.com/admin/shop.json", :body => load_fixture('shop.json')
 
     SinatraApp.any_instance.expects(:render_pdf).with do |shop, order, charity, donation|
-      assert_equal '477.60', donation.donation_amount.to_s
+      assert_equal '477.60', donation.donation_amount
     end
 
     Pony.expects(:mail).once

--- a/test/render_pdf_test.rb
+++ b/test/render_pdf_test.rb
@@ -4,37 +4,52 @@ require_relative '../src/utils/render_pdf'
 class RenderPdfTest < ActiveSupport::TestCase
 
   setup do
-    shop_domain = "apple.myshopify.com"
-    activate_shopify_session(shop_domain, 'token')
+    @shop_domain = "apple.myshopify.com"
+    activate_shopify_session(@shop_domain, 'token')
     @shop = ShopifyAPI::Shop.new(JSON.parse(load_fixture('shop.json')))
-    @charity = Charity.find_by(shop: shop_domain)
+    @charity = Charity.find_by(shop: @shop_domain)
   end
 
   test "regular_order" do
     order = JSON.parse(load_fixture('order_webhook.json'))
-    pdf = render_pdf(@shop, order, @charity, 20)
+    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
+    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+
+    pdf = render_pdf(@shop, order, @charity, donation)
     write_pdf(pdf)
   end
 
   test "order_no_address" do
     order = JSON.parse(load_fixture('order_no_address.json'))
-    pdf = render_pdf(@shop, order, @charity, 20)
+    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
+    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+
+    pdf = render_pdf(@shop, order, @charity, donation)
   end
 
   test "order_no_billing_address_uses_customer_default_address" do
     order = JSON.parse(load_fixture('order_customer_address.json'))
-    pdf = render_pdf(@shop, order, @charity, 20)
+    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
+    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+
+    pdf = render_pdf(@shop, order, @charity, donation)
   end
 
   test "order_no_zip" do
     order = JSON.parse(load_fixture('order_no_zip.json'))
-    pdf = render_pdf(@shop, order, @charity, 20)
+    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
+    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+
+    pdf = render_pdf(@shop, order, @charity, donation)
   end
 
   test "utf8" do
     @charity.name += 'Ş'
     order = JSON.parse(load_fixture('order_webhook.json'))
-    pdf = render_pdf(@shop, order, @charity, 20)
+    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
+    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+
+    pdf = render_pdf(@shop, order, @charity, donation)
   end
 
   private

--- a/test/render_pdf_test.rb
+++ b/test/render_pdf_test.rb
@@ -13,7 +13,7 @@ class RenderPdfTest < ActiveSupport::TestCase
   test "regular_order" do
     order = JSON.parse(load_fixture('order_webhook.json'))
     donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+    donation.order = ShopifyAPI::Order.new(order)
 
     pdf = render_pdf(@shop, order, @charity, donation)
     write_pdf(pdf)
@@ -22,7 +22,7 @@ class RenderPdfTest < ActiveSupport::TestCase
   test "order_no_address" do
     order = JSON.parse(load_fixture('order_no_address.json'))
     donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+    donation.order = ShopifyAPI::Order.new(order)
 
     pdf = render_pdf(@shop, order, @charity, donation)
   end
@@ -30,7 +30,7 @@ class RenderPdfTest < ActiveSupport::TestCase
   test "order_no_billing_address_uses_customer_default_address" do
     order = JSON.parse(load_fixture('order_customer_address.json'))
     donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+    donation.order = ShopifyAPI::Order.new(order)
 
     pdf = render_pdf(@shop, order, @charity, donation)
   end
@@ -38,7 +38,7 @@ class RenderPdfTest < ActiveSupport::TestCase
   test "order_no_zip" do
     order = JSON.parse(load_fixture('order_no_zip.json'))
     donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+    donation.order = ShopifyAPI::Order.new(order)
 
     pdf = render_pdf(@shop, order, @charity, donation)
   end
@@ -47,7 +47,7 @@ class RenderPdfTest < ActiveSupport::TestCase
     @charity.name += 'Ş'
     order = JSON.parse(load_fixture('order_webhook.json'))
     donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.instance_variable_set(:@order, ShopifyAPI::Order.new(order))
+    donation.order = ShopifyAPI::Order.new(order)
 
     pdf = render_pdf(@shop, order, @charity, donation)
   end

--- a/test/render_pdf_test.rb
+++ b/test/render_pdf_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require_relative '../src/utils/donation_service'
 require_relative '../src/utils/render_pdf'
 
 class RenderPdfTest < ActiveSupport::TestCase
@@ -12,8 +13,7 @@ class RenderPdfTest < ActiveSupport::TestCase
 
   test "regular_order" do
     order = JSON.parse(load_fixture('order_webhook.json'))
-    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.order = ShopifyAPI::Order.new(order)
+    donation = build_donation(@shop_domain, order, 20)
 
     pdf = render_pdf(@shop, order, @charity, donation)
     write_pdf(pdf)
@@ -21,24 +21,21 @@ class RenderPdfTest < ActiveSupport::TestCase
 
   test "order_no_address" do
     order = JSON.parse(load_fixture('order_no_address.json'))
-    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.order = ShopifyAPI::Order.new(order)
+    donation = build_donation(@shop_domain, order, 20)
 
     pdf = render_pdf(@shop, order, @charity, donation)
   end
 
   test "order_no_billing_address_uses_customer_default_address" do
     order = JSON.parse(load_fixture('order_customer_address.json'))
-    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.order = ShopifyAPI::Order.new(order)
+    donation = build_donation(@shop_domain, order, 20)
 
     pdf = render_pdf(@shop, order, @charity, donation)
   end
 
   test "order_no_zip" do
     order = JSON.parse(load_fixture('order_no_zip.json'))
-    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.order = ShopifyAPI::Order.new(order)
+    donation = build_donation(@shop_domain, order, 20)
 
     pdf = render_pdf(@shop, order, @charity, donation)
   end
@@ -46,8 +43,7 @@ class RenderPdfTest < ActiveSupport::TestCase
   test "utf8" do
     @charity.name += 'Ş'
     order = JSON.parse(load_fixture('order_webhook.json'))
-    donation = Donation.new(shop: @shop_domain, order_id: order['id'], donation_amount: 20)
-    donation.order = ShopifyAPI::Order.new(order)
+    donation = build_donation(@shop_domain, order, 20)
 
     pdf = render_pdf(@shop, order, @charity, donation)
   end


### PR DESCRIPTION
Before the templates can be updated to use the Donation model instead of Order directly (thus encapsulating access logic and simplifying templates, #37) the donation object needs to be passed in. This is necessary to avoid crashes and race conditions during the template migration.