### PR TITLE
update templates and test the update migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.mp4
 ngrok
 test.pdf
+test/fixtures/templates.csv

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-flash3 (1.0.5)
       rack
     rack-protection (2.0.1)
@@ -153,7 +153,7 @@ GEM
       sinatra (~> 2.0.1)
       sinatra-activerecord (~> 2.0.9)
       sinatra-redis (~> 0.3.0)
-    shopify_api (4.10.0)
+    shopify_api (4.11.0)
       activeresource (>= 3.0.0)
       rack
     sinatra (2.0.1)

--- a/db/migrate/20180430144346_update_templates.rb
+++ b/db/migrate/20180430144346_update_templates.rb
@@ -1,0 +1,95 @@
+class UpdateTemplates < ActiveRecord::Migration[5.1]
+  TRANSFORMATIONS = {
+    "{{ order['number'] }}" => "{{ donation.order_number }}",
+    "{{ order['created_at'] }}" => "{{ donation.created_at }}",
+    "{{ order['billing_address']['first_name'] }}" => "{{ donation.first_name }}",
+    "{{ order['billing_address']['last_name'] }}" => "{{ donation.last_name }}",
+    "{{ order['customer']['first_name'] }}" => "{{ donation.first_name }}",
+    "{{ order['customer']['last_name'] }}" => "{{ vdonation.last_name}}",
+    "{{ address['first_name'] }}" => "{{ donation.first_name }}",
+    "{{ address['last_name'] }}" => "{{ donation.last_name }}",
+    "{{ address['address1'] }}" => "{{ donation.address1 }}",
+    "{{ address['city'] }}" => "{{ donation.city }}",
+    "{{ address['country'] }}" => "{{ donation.country }}",
+    "{{ address['zip' }}" => "{{ donation.address.zip }}",
+    "{{ customer.first_name }}" => "{{ donation.first_name }}",
+    "{{ donation_amount }}" => "{{ donation.donation_amount }}",
+  }
+
+  IGNORE = [
+    "{{ email_title }}",
+    "{{ charity['name'] }}",
+    "{{ charity.name }}",
+    "{{ charity.charity_id }}",
+    "{{ shop['logo'] }}",
+    "{{ shop['city'] }}",
+    "{{ shop['address1'] }}",
+    "{{ shop.email_accent_color }}",
+    "{{ donation.first_name }}",
+    "{{ donation.last_name }}"
+  ]
+
+  UNHANDLED = [
+    "{{ shop['province'] }}",
+    "{{ shop['zip'] }}",
+    "{{ order['total_price'] }}",
+    "{{ order['total_price' }}",
+    "{{store url=\"\"}}",
+    "{{var logo_alt}}",
+    "{{ address['state'] }}",
+    "{{ address['zip'] }}",
+    "{{\"last_name }}",
+    "{{ \"address1\"}}",
+    "{{\"address2\" }}",
+    "{{ \"city\"}}",
+    "{{\"province\" }}",
+    "{{\"zip\" }}",
+    "{{ address['province'] }}",
+    "{{ order['name'] }}",
+    "{{ charity['name'], Inc. }}",
+    "{{shop.email_logo_url}}",
+    "{{ shop.name }}",
+    "{{ shop.email_logo_width }}",
+    "{{shop.url}}",
+    "{{ order_name }}",
+    "{{ email_body }}",
+    "{{ order_status_url }}",
+    "{{ shop.url }}",
+    "{{ order_number }}",
+    "{{ order['customer']['email'] }}",
+    "{{ order ['customer']['phone'] }}",
+    "{{ order['billing_address']['address1'] }}",
+    "{{ order['billing_address']['address2'] }}",
+    "{{ order['billing_address']['city'] }}",
+    "{{ order['billing_address']['province'] }}",
+    "{{ order['billing_address']['country'] }}",
+    "{{ order['billing_address']['zip'] }}",
+    "{{ attribute['name'] }}",
+    "{{ attribute['value'] }}",
+    "{{ line_item.title }}",
+    "{{ order['note'] }}"
+  ]
+
+  def self.up
+    # update email templates
+    Charity.where.not(email_template: nil).find_each do |charity|
+      new_template = apply_transformations(charity.email_template)
+      charity.update_columns(email_template: new_template)
+    end
+
+    # update pdf templates
+    Charity.where.not(pdf_template: nil).find_each do |charity|
+      new_template = apply_transformations(charity.pdf_template)
+      charity.update_columns(pdf_template: new_template)
+    end
+  end
+
+  def self.apply_transformations(template)
+    TRANSFORMATIONS.each do |old_value, new_value|
+      puts "updating #{old_value} to #{new_value}"
+      template.gsub!(old_value, new_value)
+    end
+
+    template
+  end
+end

--- a/src/utils/render_pdf.rb
+++ b/src/utils/render_pdf.rb
@@ -23,8 +23,10 @@ end
 require 'wicked_pdf'
 
 def render_pdf(shop, order, charity, donation)
-  order['created_at'] = Time.parse(order['created_at']).strftime("%B %d, %Y")
-  order['billing_address'] ||= order.dig('default_address')
+  if order
+    order['created_at'] = Time.parse(order['created_at']).strftime("%B %d, %Y")
+    order['billing_address'] ||= order.dig('default_address')
+  end
 
   template = Tilt::LiquidTemplate.new { |t| charity.pdf_template }
   pdf_content = template.render(

--- a/test/template_migration_test.rb
+++ b/test/template_migration_test.rb
@@ -1,0 +1,116 @@
+require 'test_helper'
+require 'set'
+require 'tempfile'
+require_relative '../db/migrate/20180430144346_update_templates'
+
+class TemplateMigrationTest < ActiveSupport::TestCase
+
+  setup do
+    reset_db
+    activate_shopify_session('apple.myshopify.com', 'token') # required to initiatilize new ShopifyAPI Objects ...
+  end
+
+  PRE_BROKEN_TEMPLATES = [
+    271, 496
+  ]
+
+  test "transform includes all used fields" do
+    liquid_tag_regex = /{{[^}]*}}/
+
+    found_vars = Set.new
+
+    templates_csv.each_line("\n") do |row|
+      columns = row.split("|")
+      id = columns[0]
+      email_template = columns[1]
+      pdf_template = columns[2]
+
+      email_vars = email_template.scan(liquid_tag_regex)
+      pdf_vars = pdf_template.scan(liquid_tag_regex)
+
+      email_vars.each { |v| found_vars.add(v.strip) }
+      pdf_vars.each { |v| found_vars.add(v.strip) }
+    end
+
+    handled_vars = UpdateTemplates::TRANSFORMATIONS.keys + UpdateTemplates::IGNORE
+    unhandled_vars = found_vars - Set.new(handled_vars)
+    assert_equal [], unhandled_vars.to_a
+  end
+
+  # test "migration" do
+  #   create_charities
+  #   run_migration
+  #   render_all
+  # end
+
+  def templates_csv
+    filename = 'test/fixtures/templates.csv'
+    file = File.new(filename, 'r')
+  rescue
+    charity = Charity.new
+    temp_file = Tempfile.new('templates.csv')
+    temp_file.write("1, #{charity.email_template.inspect}, #{charity.pdf_template.inspect}\n")
+    temp_file.rewind
+    temp_file
+  end
+
+  def create_charities
+    templates_csv.each_line("\n") do |row|
+      columns = row.split("|")
+      id = columns[0]
+      email_template = columns[1]
+      pdf_template = columns[2]
+
+      Charity.create!(
+        id: id,
+        name: id,
+        charity_id: id,
+        shop: id,
+        email_template: email_template,
+        pdf_template: pdf_template
+      )
+    end
+
+    assert_equal 281, Charity.count
+  end
+
+  def run_migration
+    UpdateTemplates.up
+  end
+
+  def render_all
+    Charity.find_each { |charity| render_templates(charity) }
+  end
+
+  def render_templates(charity)
+    if PRE_BROKEN_TEMPLATES.include?(charity.id)
+      puts "skipping charity #{charity.id} due to an exisiting error"
+      return
+    end
+
+    puts "rendering charity #{charity.id}"
+
+    # render email template
+    template = Tilt::LiquidTemplate.new { |t| charity.email_template }
+    template.render(charity.email_template, layout: false, locals: {charity: charity, donation: mock_donation})
+
+    # render pdf template
+    pdf_string = render_pdf(shop, nil, charity, mock_donation)
+
+    # save to file
+    File.open('test.pdf', 'w') { |file| file.write(pdf_string) }
+  end
+
+  def shop
+    attributes = JSON.parse(load_fixture('shop.json'))
+    ShopifyAPI::Shop.new(attributes)
+  end
+
+  def mock_donation
+    build_donation('apple.myshopify.com', mock_order, 20.00)
+  end
+
+  def mock_order
+    JSON.parse( File.read(File.join('test', 'fixtures/order_webhook.json')) )
+  end
+end


### PR DESCRIPTION
This PR automatically migrates all the templates to use the Donation model in liquid instead of the Order. This simplifies the templates and code a fair bit.

### Testing
To generate templates.csv run `heroku pg:psql` then
```
\copy (SELECT id, email_template, pdf_template from charities) TO test/fixtures/templates.csv DELIMITER ',';
```