### PR TITLE
add order_number column and backfill

### DIFF
--- a/db/migrate/20180511143119_add_order_number.rb
+++ b/db/migrate/20180511143119_add_order_number.rb
@@ -1,0 +1,5 @@
+class AddOrderNumber < ActiveRecord::Migration[5.1]
+  def change
+    add_column :donations, :order_number, :string
+  end
+end

--- a/db/migrate/20180511143155_backfill_order_number.rb
+++ b/db/migrate/20180511143155_backfill_order_number.rb
@@ -1,0 +1,12 @@
+class BackfillOrderNumber < ActiveRecord::Migration[5.1]
+  def change
+    Donation.find_each { |donation| backfill(donation) }
+  end
+
+  def backfill(donation)
+    shop = Shop.find_by(name: donation.shop)
+    ShopifyAPI::Session.temp(shop.name, shop.token) do
+      donation.update_columns(order_number: donation.order.name)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180329135133) do
+ActiveRecord::Schema.define(version: 20180511143155) do
 
   create_table "charities", force: :cascade do |t|
     t.string "name", limit: 255
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20180329135133) do
     t.integer "order_id", limit: 8, null: false
     t.decimal "donation_amount", precision: 8, scale: 2, null: false
     t.datetime "created_at", null: false
+    t.string "order_number"
     t.index ["shop"], name: "index_donations_on_shop"
   end
 

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -20,14 +20,6 @@ class Donation < ActiveRecord::Base
     order.billing_address || order.attributes.dig('default_address')
   end
 
-  def order_name
-    order.name
-  end
-
-  def order_number
-    order.number
-  end
-
   def email
     order.customer.email
   end
@@ -49,7 +41,6 @@ class Donation < ActiveRecord::Base
 
   def to_liquid
     {
-      'order_name' => order_name,
       'order_number' => order_number,
       'email' => email,
       'first_name' => first_name,

--- a/views/help.erb
+++ b/views/help.erb
@@ -34,7 +34,6 @@ charity_id
 
 <strong>donation</strong>
 <pre>
-order_name
 order_number
 email
 first_name


### PR DESCRIPTION
A user needs the order_number included in the export. Because this field was delegated to order it wasn't included in the export. This PR adds a column and backfills it to denormalize the data for export.

Note to test locally I had to run with foreman to include ENV vars so that the attr_encrypted token on shop was able to be read:

```
foreman run bundle exec rake db:migrate 
```

This PR can be used as a template for the first step in adding a new field to donation for export