### PR TITLE
guard nil charity

### DIFF
--- a/src/jobs/order_webhook_job.rb
+++ b/src/jobs/order_webhook_job.rb
@@ -3,14 +3,15 @@ class OrderWebhookJob < Job
     return unless order['customer']
     return unless order['customer']['email']
 
-    activate_shopify_api(shop_name)
-
     donations = donations_from_order(shop_name, order)
+    donation_amount = donations.sum
     return if donations.empty?
 
     charity = Charity.find_by(shop: shop_name)
+    return if charity.nil?
+
+    activate_shopify_api(shop_name)
     shopify_shop = ShopifyAPI::Shop.current
-    donation_amount = donations.sum
 
     return if charity.receipt_threshold.present? && donation_amount < charity.receipt_threshold
 

--- a/test/order_test.rb
+++ b/test/order_test.rb
@@ -11,6 +11,17 @@ class OrderTest < ActiveSupport::TestCase
     @noop_shop = "banana.myshopify.com"
   end
 
+  # possible using the app link
+  test "order with products but no charity" do
+    Charity.where(shop: @shop).destroy_all
+
+    order_webhook = load_fixture 'order_webhook.json'
+    SinatraApp.any_instance.expects(:verify_shopify_webhook).returns(true)
+    Pony.expects(:mail).never
+    post '/order.json', order_webhook, 'HTTP_X_SHOPIFY_SHOP_DOMAIN' => @shop
+    assert last_response.ok?
+  end
+
   test "order with no products" do
     order_webhook = load_fixture 'order_webhook.json'
 


### PR DESCRIPTION
closes #23

Generally a user has to save their charity before they can use the App UI and add products. However if they use the app link they can have products without a charity. This protects against a crash in that situation. I prefer this fix over blocking the app action if the charity is missing.