### PR TITLE
pass live edited template to preview method. add status to pdf preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ end
 group :development do
   gem 'sqlite3'
   gem 'wkhtmltopdf-binary'
+  gem 'pdf-inspector'
   gem 'letter_opener'
   gem 'rack-test'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.0.3)
     actionview (5.2.1)
       activesupport (= 5.2.1)
       builder (~> 3.1)
@@ -39,6 +40,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    afm (0.2.2)
     arel (9.0.0)
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
@@ -61,6 +63,7 @@ GEM
     graphql-client (0.14.0)
       activesupport (>= 3.0, < 6.0)
       graphql (~> 1.6)
+    hashery (2.1.2)
     hashie (3.6.0)
     httparty (0.16.3)
       mime-types (~> 3.0)
@@ -119,6 +122,14 @@ GEM
       padrino-support (= 0.14.3)
       tilt (>= 1.4.1, < 3)
     padrino-support (0.14.3)
+    pdf-inspector (1.3.0)
+      pdf-reader (>= 1.0, < 3.0.a)
+    pdf-reader (2.2.0)
+      Ascii85 (~> 1.0.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (1.1.0)
     pony (1.12)
       mail (>= 2.0)
@@ -145,6 +156,7 @@ GEM
       json
       rack
     redis (4.1.0)
+    ruby-rc4 (0.1.5)
     shopify-sinatra-app (0.6.0)
       activesupport
       attr_encrypted (~> 3.1.0)
@@ -181,6 +193,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    ttfunk (1.5.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     wicked_pdf (1.1.0)
@@ -200,6 +213,7 @@ DEPENDENCIES
   letter_opener
   liquid
   mocha
+  pdf-inspector
   pg
   pony
   pry

--- a/src/app.rb
+++ b/src/app.rb
@@ -168,11 +168,17 @@ class SinatraApp < Sinatra::Base
   end
 
   # render a preview of the user edited pdf template
-  get '/preview_pdf' do
+  post '/preview_pdf' do
     shopify_session do |shop_name|
       donation = mock_donation(shop_name)
       charity = Charity.find_by(shop: shop_name)
       shopify_shop = ShopifyAPI::Shop.current
+
+      charity.assign_attributes({pdf_template: params['template']})
+
+      if params['status'] == 'void'
+        donation.assign_attributes({status: 'void'})
+      end
 
       receipt_pdf = render_pdf(shopify_shop, charity, donation)
       content_type 'application/pdf'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require 'rack/test'
 
 require 'database_cleaner'
 require 'sidekiq/testing'
+require 'pdf/inspector'
 require 'mocha/setup'
 require 'fakeweb'
 require 'json'

--- a/views/components/_pdf_modal.erb
+++ b/views/components/_pdf_modal.erb
@@ -7,31 +7,43 @@
         <h4 class="modal-title">Edit Donation Receipt Pdf</h4>
       </div>
 
-      <form method="POST" action="/charity" role="form">
-        <input type="hidden" name="_method" value="put" />
-        <div class="modal-body">
+      <div class="modal-body">
+        <label>Preview Options</label>
+        <select class="form-control" style="width: 97%" value="default" bind="previewOptions">
+          <option value="default">Default</option>
+          <option value="void">Void</option>
+        </select>
 
-          <label for="pdf_body">Pdf Template</label>
-          <textarea class="form-control" name="pdf_template" id="pdf_template" rows="18" style="width: 97%">
-            <%= charity.pdf_template %>
-          </textarea>
+        <label style="padding-top: 10px;">Pdf Template</label>
+        <textarea
+          bind="pdfTemplate"
+          class="form-control"
+          style="width: 97%"
+          rows="18"><%= charity.pdf_template %></textarea>
+      </div>
+
+      <div class="modal-footer">
+        <div class="pull-left">
+          <form method="POST" action="/preview_pdf" target="_blank" role="form">
+            <input type="hidden" name="template" value="<%= charity.pdf_template %>" bind="pdfTemplate" />
+            <input type="hidden" name="status" value="default" bind="previewOptions" />
+            <button type="submit" class="btn btn-default">Preview</button>
+          </form>
         </div>
 
-        <div class="modal-footer">
-          <div class="pull-left">
-             <a href="/preview_pdf" target="_blank" class="btn btn-default">Preview</a>
-          </div>
+        <form method="POST" action="/charity" role="form">
+          <input type="hidden" name="_method" value="put" />
+          <input type="hidden" name="pdf_template" value="<%= charity.pdf_template %>" bind="pdfTemplate" />
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
           <button type="submit" class="btn btn-primary">Save</button>
-        </div>
-      </form>
-
+        </form>
+      </div>
     </div>
   </div>
 </div>
 
 <p>
   <a href="#" class="btn btn-default action-btn" onclick="$('#editPdfModal').modal('toggle'); return false;">
-    <i class="fa fa-edit"></i>  Edit receipt pdf
+    <i class="fa fa-edit"></i> Edit receipt pdf
   </a>
 </p>


### PR DESCRIPTION
closes #18

Makes preview_pdf into a proper form with POST so I can include a body of the current template. This means you don't have to save before previewing. It also lets me send other parameters to test other states, like VOID. This will be required as the PDF gets more states like updated, resent and refunded.

This makes use of smart data binding to use shadow forms that actually submit which are different than the form the user actually edits. This lets me have 2 forms on the same page without nesting them,