### PR TITLE
add resent state and modify default template

### DIFF
--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -1,7 +1,15 @@
 class Donation < ActiveRecord::Base
   validates_presence_of :shop, :order_id, :donation_amount
   validates_uniqueness_of :order_id, scope: :shop, conditions: -> { where(status: nil) }
-  validates :status, inclusion: { in: %w(void refunded) }, allow_nil: true
+  validates :status, inclusion: { in: %w(resent void) }, allow_nil: true
+
+  def resent!
+    update!({status: 'resent'})
+  end
+
+  def resent
+    status == 'resent'
+  end
 
   def void!
     update!({status: 'void'})
@@ -9,14 +17,6 @@ class Donation < ActiveRecord::Base
 
   def void
     status == 'void'
-  end
-
-  def refunded!
-    update!({status: 'refunded'})
-  end
-
-  def refunded
-    status == 'refunded'
   end
 
   def order=(shopify_order)
@@ -58,7 +58,9 @@ class Donation < ActiveRecord::Base
 
   def to_liquid
     {
+      'id' => id,
       'order_number' => order_number,
+      'status' => status,
       'email' => email,
       'first_name' => first_name,
       'last_name' => last_name,

--- a/src/utils/render_pdf.rb
+++ b/src/utils/render_pdf.rb
@@ -38,8 +38,7 @@ def render_pdf(shop, charity, donation)
     Tilt::ERBTemplate.new('views/receipt/pdf.erb').render(
       Object.new,
       pdf_content: pdf_content,
-      void: donation.void,
-      refunded: donation.refunded
+      void: donation.void
     )
   )
 end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -57,19 +57,6 @@ class AppTest < ActiveSupport::TestCase
     assert_equal 'Donation is void', last_request.env['x-rack.flash'][:error]
   end
 
-  test "cant resend refunded" do
-    order_id = 1234
-    donation = Donation.create!(shop: @shop, order_id: order_id, donation_amount: 10, status: 'refunded')
-
-    fake "https://apple.myshopify.com/admin/shop.json", :body => load_fixture('shop.json')
-
-    params = {id: donation.id}
-    post '/resend', params, 'rack.session' => session
-
-    assert last_response.redirect?
-    assert_equal 'Donation is refunded', last_request.env['x-rack.flash'][:error]
-  end
-
   test "preview_email" do
     fake "https://apple.myshopify.com/admin/shop.json", :body => load_fixture('shop.json')
 

--- a/test/render_pdf_test.rb
+++ b/test/render_pdf_test.rb
@@ -56,14 +56,6 @@ class RenderPdfTest < ActiveSupport::TestCase
     pdf = render_pdf(@shop, @charity, donation)
   end
 
-  test "refunded" do
-    order = JSON.parse(load_fixture('order_webhook.json'))
-    donation = build_donation(@shop_domain, order, 20)
-    donation.refunded!
-
-    pdf = render_pdf(@shop, @charity, donation)
-  end
-
   private
 
   def write_pdf(pdf_string)

--- a/views/_donations.erb
+++ b/views/_donations.erb
@@ -13,7 +13,7 @@
       </tr>
 
       <% donations.each do |donation| %>
-        <% disabled = donation.void || donation.refunded %>
+        <% disabled = donation.void %>
 
         <tr>
           <td>

--- a/views/components/_pdf_modal.erb
+++ b/views/components/_pdf_modal.erb
@@ -11,6 +11,7 @@
         <label>Preview Options</label>
         <select class="form-control" style="width: 97%" value="default" bind="previewOptions">
           <option value="default">Default</option>
+          <option value="resent">Resent</option>
           <option value="void">Void</option>
         </select>
 

--- a/views/help.erb
+++ b/views/help.erb
@@ -46,7 +46,9 @@ charity_id
 
 <strong>donation</strong>
 <pre>
+id
 order_number
+status (blank | resent | void)
 email
 first_name
 last_name

--- a/views/receipt/pdf.erb
+++ b/views/receipt/pdf.erb
@@ -26,10 +26,6 @@
       <div id='watermark'>
         <p>VOID</p>
       </div>
-    <% elsif refunded %>
-      <div id='watermark'>
-        <p>REFUNDED</p>
-      </div>
     <% end %>
   </body>
 </html>

--- a/views/receipt/pdf.liquid
+++ b/views/receipt/pdf.liquid
@@ -7,7 +7,6 @@
 </div>
 <div style="clear: both;">
 
-
 <div style="font-size: 10pt; margin-top: 180px; margin-left: 100px;">
   <strong>
     {{ donation.first_name }} {{ donation.last_name }}
@@ -25,7 +24,12 @@
     Donation Details:
   </strong>
   <br>
-  Receipt Number: #{{ donation.order_number }}<br>
+  Order Number: {{ donation.order_number }}<br>
+  {% if donation.status == 'resent' %}
+    Replacement for Receipt Number: #{{ donation.id }}<br>
+  {% else %}
+    Receipt Number: #{{ donation.id }}<br>
+  {% endif %}
   Donation Received: {{ donation.created_at }}<br>
   Amount: ${{ donation.donation_amount }}<br>
   Date Issued: {{ donation.created_at }}<br>


### PR DESCRIPTION
This adds a resent state for when the receipt is resent. The donation ID and status is added to the liquid drop to allow using this data when generating receipts.

I also removed the refunded state for now since it's not clear if  it is going to be required. Void may be sufficient.