### PR TITLE
Require billing address

### DIFF
--- a/src/jobs/order_webhook_job.rb
+++ b/src/jobs/order_webhook_job.rb
@@ -22,8 +22,9 @@ class OrderWebhookJob < Job
 
   # order_paid
   def order_paid(shop_name, order)
+    return unless order['email']
     return unless order['customer']
-    return unless order['customer']['email']
+    return unless order['billing_address']
 
     donations = donations_from_order(shop_name, order)
     donation_amount = donations.sum

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -24,10 +24,7 @@ class Donation < ActiveRecord::Base
   end
 
   delegate :email, to: :order
-
-  def address
-    order.try(:billing_address) || order.attributes.dig('default_address')
-  end
+  delegate :billing_address, to: :order
 
   delegate :first_name,
            :last_name,
@@ -38,7 +35,7 @@ class Donation < ActiveRecord::Base
            :province,
            :country,
            :zip,
-           to: :address
+           to: :billing_address
 
   def original_donation=(donation)
     @original_donation = donation
@@ -57,7 +54,6 @@ class Donation < ActiveRecord::Base
   def order_to_liquid
     drop = JSON.parse(order.to_json)
     drop['created_at'] = Time.parse(drop['created_at']).strftime("%B %d, %Y")
-    drop['billing_address'] ||= drop.dig('default_address')
     drop
   end
 

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -26,7 +26,7 @@ class Donation < ActiveRecord::Base
   delegate :email, to: :order
 
   def address
-    order.billing_address || order.attributes.dig('default_address')
+    order.try(:billing_address) || order.attributes.dig('default_address')
   end
 
   delegate :first_name,

--- a/test/order_test.rb
+++ b/test/order_test.rb
@@ -52,7 +52,7 @@ class OrderTest < ActiveSupport::TestCase
 
   test "order with no email" do
     order_webhook = JSON.parse(load_fixture('order.json'))
-    order_webhook['customer'].delete('email')
+    order_webhook.delete('email')
     order_webhook = order_webhook.to_json
 
     SinatraApp.any_instance.expects(:verify_shopify_webhook).returns(true)
@@ -69,6 +69,22 @@ class OrderTest < ActiveSupport::TestCase
   test "order with no customer" do
     order_webhook = JSON.parse(load_fixture('order.json'))
     order_webhook.delete('customer')
+    order_webhook = order_webhook.to_json
+
+    SinatraApp.any_instance.expects(:verify_shopify_webhook).returns(true)
+    fake "https://apple.myshopify.com/admin/shop.json", :body => load_fixture('shop.json')
+
+    Pony.expects(:mail).never
+
+    assert_no_difference 'Donation.count' do
+      post '/order', order_webhook, 'HTTP_X_SHOPIFY_SHOP_DOMAIN' => @shop
+      assert last_response.ok?
+    end
+  end
+
+  test "order with no billing_address" do
+    order_webhook = JSON.parse(load_fixture('order.json'))
+    order_webhook.delete('billing_address')
     order_webhook = order_webhook.to_json
 
     SinatraApp.any_instance.expects(:verify_shopify_webhook).returns(true)


### PR DESCRIPTION
An export job started crashing since adding the extra fields because the order doesn't have a billing address. While investigating I realized my delegation to default_address didn't even work. Given the lack of crashes without this delegation and the complexity it adds I think it makes sense to remove. 

If an order does not have a billing address and a customer it should not get aa receipt since there is not enough information to do so.

Donation 8514 should be removed from production