### PR TITLE
Recieved_at should not update if the receipt is re-issued

### DIFF
--- a/src/app.rb
+++ b/src/app.rb
@@ -237,5 +237,7 @@ class SinatraApp < Sinatra::Base
 
   def mock_order
     @mock_order ||= JSON.parse( File.read(File.join('test', 'fixtures/order.json')) )
+    @mock_order['created_at'] = Time.now
+    @mock_order
   end
 end

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -23,6 +23,10 @@ class Donation < ActiveRecord::Base
     @order ||= load_order
   end
 
+  def received_at
+    Time.parse(order.created_at).strftime("%B %d, %Y")
+  end
+
   delegate :email, to: :order
   delegate :billing_address, to: :order
 
@@ -69,6 +73,7 @@ class Donation < ActiveRecord::Base
       'city' => city,
       'country' => country,
       'zip' => zip,
+      'received_at' => received_at,
       'created_at' => (created_at || Time.now).strftime("%B %d, %Y"),
       'donation_amount' => sprintf( "%0.02f", donation_amount),
       'original_donation' => original_donation && original_donation.to_liquid

--- a/views/help.erb
+++ b/views/help.erb
@@ -65,6 +65,7 @@ address1
 city
 country
 zip
+received_at
 created_at
 donation_amount
 original_donation (only present if status == 'update')

--- a/views/receipt/pdf.liquid
+++ b/views/receipt/pdf.liquid
@@ -33,7 +33,7 @@
   {% if donation.status == 'update' %}
     Replacement for Receipt Number: #{{ donation.original_donation.id }}<br>
   {% endif %}
-  Donation Received: {{ donation.created_at }}<br>
+  Donation Received: {{ donation.received_at }}<br>
   Amount: ${{ donation.donation_amount }}<br>
   Date Issued: {{ donation.created_at }}<br>
   Place Issued: {{ shop['city'] }}


### PR DESCRIPTION
update template to use the order.created_at for donation received_at. created_at might not always match paid_at (which isn't a field) but this is better than it changing when the donation is re-issued. If a shop has a flow that runs into the case where paid_at != created_at a new field can be added to the donation that is copied forwards on update.