### PR TITLE
explore html email

### DIFF
--- a/db/migrate/20181228050905_update_templates.rb
+++ b/db/migrate/20181228050905_update_templates.rb
@@ -1,6 +1,6 @@
 class UpdateTemplates < ActiveRecord::Migration[5.2]
   def change
-    add_column :charities, :update_email_template, :string
-    add_column :charities, :update_email_subject, :string
+    #add_column :charities, :update_email_template, :string
+    #add_column :charities, :update_email_subject, :string
   end
 end

--- a/src/utils/email_service.rb
+++ b/src/utils/email_service.rb
@@ -47,10 +47,19 @@ def email_body(email_template, charity, donation)
 end
 
 def send_email(to, bcc, from, subject, body, pdf, filename)
-  Pony.mail to: to,
-            bcc: bcc,
-            from: from,
-            subject: subject,
-            attachments: {"#{filename}.pdf" => pdf},
-            body: body
+  options = {
+    to: to,
+    bcc: bcc,
+    from: from,
+    subject: subject,
+    attachments: {"#{filename}.pdf" => pdf}
+  }
+
+  if body.include?("</html>")
+    options[:html_body] = body
+  else
+    options[:body] = body
+  end
+
+  Pony.mail(options)
 end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -185,6 +185,16 @@ class AppTest < ActiveSupport::TestCase
     assert last_response.ok?
   end
 
+  test "test_html_email" do
+    charity = Charity.find_by(shop: @shop)
+
+    fake "https://apple.myshopify.com/admin/shop.json", :body => load_fixture('shop.json')
+    Pony.expects(:mail).with(has_entry(html_body: "<html>hello #{charity.name}</html>"))
+
+    get '/test_email', {email_template: '<html>hello {{ charity.name }}</html>'}, 'rack.session' => session
+    assert last_response.ok?
+  end
+
   test "test_void_email" do
     charity = Charity.find_by(shop: @shop)
 

--- a/views/components/_email_modals.erb
+++ b/views/components/_email_modals.erb
@@ -109,13 +109,11 @@
             bind="<%= template %><%= modal_id %>"
             value="<%= charity.send(template) %>"
           />
-          <textarea
+          <pre
             id="email_body"
-            class="form-control"
-            style="width: 97%"
-            rows="12"
-            disabled="true">
-          </textarea>
+            class="well"
+            style="width: 97%; height: 244px; white-space: pre-wrap; word-break: keep-all;">
+          </pre>
         </div>
 
         <div class="modal-footer">

--- a/views/help.erb
+++ b/views/help.erb
@@ -38,7 +38,7 @@ ShopifyApp.ready(function(){
 <hr>
 
 <h3>Editing Templates</h3>
-<p>You can edit the templates for the emails and receipt pdf that get sent out. The templates are written in liquid just like your Shopify theme and other shop emails.</p>
+<p>You can edit the templates for the emails and receipt pdf that get sent out. The templates are written in liquid just like your Shopify theme and other shop emails. HTML is supported in email templates. If an html close tag is detected in the template the email will be sent with an html body instead of a plain text body. Please test HTML email templates carefully!</p>
 <p>The following objects are available in the templates:</p>
 
 <strong>shop</strong>


### PR DESCRIPTION
If the email template includes an html closing tag `</html>` send it has body_html instead of body (aka html email vs plain text).