### PR TITLE
Donation number

### DIFF
--- a/db/migrate/20191111234127_add_donation_number.rb
+++ b/db/migrate/20191111234127_add_donation_number.rb
@@ -1,0 +1,5 @@
+class AddDonationNumber < ActiveRecord::Migration[5.2]
+  def change
+    add_column :donations, :donation_number, :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_08_233720) do
+ActiveRecord::Schema.define(version: 2019_11_11_234127) do
 
   create_table "charities", force: :cascade do |t|
     t.string "name", limit: 255
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2019_08_08_233720) do
     t.string "order_number"
     t.string "status"
     t.string "order"
+    t.integer "donation_number"
     t.index ["shop"], name: "index_donations_on_shop"
   end
 

--- a/src/jobs/order_webhook_job.rb
+++ b/src/jobs/order_webhook_job.rb
@@ -86,6 +86,7 @@ class OrderWebhookJob < Job
       order: order.to_json,
       order_id: order['id'],
       order_number: order['name'],
+      donation_number: existing_donation.donation_number,
       donation_amount: sprintf( "%0.02f", amount)
     )
 

--- a/src/jobs/order_webhook_job.rb
+++ b/src/jobs/order_webhook_job.rb
@@ -11,7 +11,7 @@ class OrderWebhookJob < Job
     elsif status == 'paid' && existing_donation
       order_updated(shop_name, order, existing_donation)
 
-    elsif status == 'refunded' && existing_donation
+    elsif status == 'refunded' && existing_donation && !existing_donation.void
       order_refunded(shop_name, order, existing_donation)
 
     elsif status == 'partially_refunded' && existing_donation

--- a/src/jobs/order_webhook_job.rb
+++ b/src/jobs/order_webhook_job.rb
@@ -86,7 +86,6 @@ class OrderWebhookJob < Job
       order: order.to_json,
       order_id: order['id'],
       order_number: order['name'],
-      donation_number: existing_donation.donation_number,
       donation_amount: sprintf( "%0.02f", amount)
     )
 
@@ -94,6 +93,7 @@ class OrderWebhookJob < Job
     new_donation.id = existing_donation.id
     new_donation.created_at = existing_donation.created_at
     new_donation.status = existing_donation.status
+    new_donation.donation_number = existing_donation.donation_number
     new_donation.original_donation = existing_donation.original_donation if existing_donation.status == 'update'
 
     old_receipt_pdf = render_pdf(shopify_shop, charity, existing_donation)
@@ -108,6 +108,7 @@ class OrderWebhookJob < Job
       new_donation.id = nil
       new_donation.created_at = nil
       new_donation.status = 'update'
+      new_donation.donation_number = nil
       new_donation.original_donation = existing_donation
 
       if existing_donation.thresholded && charity.receipt_threshold.present? && amount < charity.receipt_threshold

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -120,6 +120,7 @@ class Donation < ActiveRecord::Base
   end
 
   def set_donation_number
+    return if self.donation_number
     last_donation = Donation.where(shop: self.shop).order(id: :desc).limit(1).first
     last_number = last_donation.present? ? last_donation.donation_number : 0
     self.donation_number = last_number + 1

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -1,7 +1,10 @@
 class Donation < ActiveRecord::Base
   validates_presence_of :shop, :order_id, :donation_amount
   validates_uniqueness_of :order_id, scope: :shop, conditions: -> { where("status != 'void' or status is null") }
+  validates_uniqueness_of :donation_number, scope: :shop, conditions: -> { where("status != 'void' or status is null") }
   validates :status, inclusion: { in: %w(thresholded resent update void) }, allow_nil: true
+
+  before_create :set_donation_number
 
   def email_template
     product_ids = order.line_items.map { |item| item.product_id }
@@ -114,5 +117,11 @@ class Donation < ActiveRecord::Base
     ShopifyAPI::Session.temp(domain: shop.name, token: shop.token, api_version: '2019-04') do
       yield
     end
+  end
+
+  def set_donation_number
+    last_donation = Donation.where(shop: self.shop).order(id: :desc).limit(1).first
+    last_number = last_donation.present? ? last_donation.donation_number : 0
+    self.donation_number = last_number + 1
   end
 end

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -1,7 +1,6 @@
 class Donation < ActiveRecord::Base
   validates_presence_of :shop, :order_id, :donation_amount
   validates_uniqueness_of :order_id, scope: :shop, conditions: -> { where("status != 'void' or status is null") }
-  validates_uniqueness_of :donation_number, scope: :shop
   validates :status, inclusion: { in: %w(thresholded resent update void) }, allow_nil: true
 
   before_create :set_donation_number

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -1,7 +1,7 @@
 class Donation < ActiveRecord::Base
   validates_presence_of :shop, :order_id, :donation_amount
   validates_uniqueness_of :order_id, scope: :shop, conditions: -> { where("status != 'void' or status is null") }
-  validates_uniqueness_of :donation_number, scope: :shop, conditions: -> { where("status != 'void' or status is null") }
+  validates_uniqueness_of :donation_number, scope: :shop
   validates :status, inclusion: { in: %w(thresholded resent update void) }, allow_nil: true
 
   before_create :set_donation_number
@@ -120,7 +120,6 @@ class Donation < ActiveRecord::Base
   end
 
   def set_donation_number
-    return if self.donation_number
     last_donation = Donation.where(shop: self.shop).order(id: :desc).limit(1).first
     last_number = last_donation.present? ? last_donation.donation_number : 0
     self.donation_number = last_number + 1

--- a/src/tasks/backfill.rake
+++ b/src/tasks/backfill.rake
@@ -1,23 +1,15 @@
-task :backfill_products do
-  Shop.find_each { |shop| backfill_products(shop) }
+task :backfill_donation_number do
+  Shop.find_each { |shop| backfill_donation_number(shop) }
 end
 
-def backfill_products(shop)
+def backfill_donation_number(shop)
   puts "Backfilling shop: #{shop.name}"
 
-  products = Product.where(shop: shop.name, shopify_product: nil)
-
-  return unless products.present?
-
-  api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: '2019-04')
-  ShopifyAPI::Base.activate_session(api_session)
-
-  products.each do |product|
-    shopify_product = ShopifyAPI::Product.find(product.product_id)
-    product.shopify_product = shopify_product.to_json
-    product.save!
+  num = 1
+  Donation.where(shop: shop.name).order(:id).find_each do |donation|
+    donation.update_column(:donation_number, num)
+    num += 1
   end
-
 rescue => e
   puts "Error backfilling for shop #{shop.name} error: #{e}"
 end

--- a/test/donation_test.rb
+++ b/test/donation_test.rb
@@ -14,6 +14,15 @@ class DonationTest < ActiveSupport::TestCase
     refute Donation.create(shop: @shop, order_id: 1234, donation_amount: 10, status: 'thresholded').persisted?
   end
 
+  test "donation sets donation number before create" do
+    donation = Donation.create!(shop: @shop, order_id: 1, donation_amount: 10)
+    assert_equal 1, donation.donation_number
+
+    donation.update_column(:donation_number, 20)
+    new_donation = Donation.create!(shop: @shop, order_id: 2, donation_amount: 10)
+    assert_equal 21, new_donation.donation_number
+  end
+
   test "donation without order saved loads from Shopify and saves the order" do
     order_id = 1234
     donation = Donation.create(shop: @shop, order_id: order_id, donation_amount: 10)


### PR DESCRIPTION
This adds a donation number which is an incrementing ID starting at 1 for each shop. This is useful for charities' accounting tasks.

Part 1:
* add the column and model validation
* add the before_create logic to set the donation number
* modify the order update logic to not trip on a new donation number (even though donation number is not usable in liquid and may never be
*  backfill the number for each shop

When this ships new donations will be created but their numbers will be wrong until the backfill is ran. This is fine because this data is not presented anywhere yet.

Next:
* confirm the backfill
* add not null on donation_number
* add unique index
* include in csv export

This PR also includes 2 fixes to the refund handler. partial refunds can be handled the exact same as order updates and now get the "did anything important change" logic for free. The other fix is to bail out of the refunded handler if the receipt is already void. Both these fixes help remove edge cases where someone would getm extra emails.