### PR TITLE
add donation number to liquid

### DIFF
--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -80,6 +80,7 @@ class Donation < ActiveRecord::Base
   def to_liquid
     {
       'id' => id,
+      'donation_number' => donation_number,
       'order_number' => order_number,
       'status' => status,
       'email' => email,

--- a/views/help.erb
+++ b/views/help.erb
@@ -70,6 +70,7 @@ donation_id_prefix
 <strong>donation</strong>
 <pre>
 id
+donation_number
 order_number
 status (blank | resent | update | void)
 email


### PR DESCRIPTION
adds the dontation number to the liquid drop and updates the documentation.

The donation number backend was added in: https://github.com/kevinhughes27/shopify-tax-receipts/pull/110 including the logic to ensure the receipt updates function with this new field.

In some ways it probably makes more sense for the donation number to be used instead of the ID in the default templates. Making changes to the default template is safe because when I calculate the pdf diff the old and new pdf are both re-rendered meaning the template change does not affect it (where if the pdfs were stored this would not be the case).

However changing to use donation_number would add the `Donation: 1` problem which is underiserable. Then I would also need to pick a default for the prefix similar to Shopify order numbers. Also there would be a strange gap where the number type changes. 

In light of this I am electing just to add it as an option and not make it the new default.