### PR TITLE
Revert "Bump sidekiq from 6.0.3 to 6.0.4"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
-    sidekiq (6.0.4)
+    sidekiq (6.0.3)
       connection_pool (>= 2.2.2)
       rack (>= 2.0.0)
       rack-protection (>= 2.0.0)


### PR DESCRIPTION
Reverts kevinhughes27/shopify-tax-receipts#123

seems to have caused https://app.bugsnag.com/taxreceipts/taxreceipts/errors/5e00eed4d257200018f849ec?event_id=5e00eed40054c36be90f0000&i=em&m=nw