### PR TITLE
Subtract Discounts Setting

### DIFF
--- a/db/migrate/20200105191330_add_discounts_setting.rb
+++ b/db/migrate/20200105191330_add_discounts_setting.rb
@@ -1,0 +1,5 @@
+class AddDiscountsSetting < ActiveRecord::Migration[5.2]
+  def change
+    add_column :charities, :subtract_discounts, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_13_153523) do
+ActiveRecord::Schema.define(version: 2020_01_05_191330) do
 
   create_table "charities", force: :cascade do |t|
     t.string "name", limit: 255
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_153523) do
     t.string "update_email_template"
     t.string "update_email_subject"
     t.string "donation_id_prefix"
+    t.boolean "subtract_discounts", default: false, null: false
     t.index ["shop"], name: "index_charities_on_shop"
   end
 

--- a/playbook.md
+++ b/playbook.md
@@ -15,8 +15,8 @@ SIDEKIQ_PASSWORD=
 DEVELOPMENT=1
 
 Install `forward` with `gem install forward`
-Make sure the tunnel is started `forward 5000 shopify`
-The development app is configured for https://shopify-kevinhughes27.fwd.wf
+Make sure the tunnel is started `./ngrok http 5000`
+Then configure your Shopify API Client to use the ngrok url.
 
 Then run `foreman start -m all=1,release=0 ` or `PORT=5000 foreman run web` if you need byebug
 

--- a/src/jobs/order_webhook_job.rb
+++ b/src/jobs/order_webhook_job.rb
@@ -168,7 +168,13 @@ class OrderWebhookJob < Job
       if donation_product
         price = item["price"].to_f
         quantity = item["quantity"].to_i
+
         total = price * quantity
+
+        if charity.subtract_discounts
+          total -= item["total_discount"].to_f
+        end
+
         donations << total * (donation_product.percentage / 100.0)
       end
     end
@@ -192,7 +198,13 @@ class OrderWebhookJob < Job
         if donation_product
           price = line_item["price"].to_f
           quantity = refund_item["quantity"].to_i
+
           total = price * quantity
+
+          if charity.subtract_discounts
+            total -= line_item["total_discount"].to_f
+          end
+
           donations << total * (donation_product.percentage / 100.0)
         end
       end

--- a/src/jobs/order_webhook_job.rb
+++ b/src/jobs/order_webhook_job.rb
@@ -33,14 +33,16 @@ class OrderWebhookJob < Job
     return unless order['customer']
     return unless order['billing_address']
 
-    donation_products = Product.where(shop: shop_name)
-
-    donations = donations_from_order(order, donation_products)
-    donation_amount = donations.sum
-    return if donations.empty?
-
     charity = Charity.find_by(shop: shop_name)
     return if charity.nil?
+
+    donation_products = Product.where(shop: shop_name)
+    return if donation_products.empty?
+
+    donations = donations_from_order(order, charity, donation_products)
+    return if donations.empty?
+
+    donation_amount = donations.sum
 
     donation = Donation.new(
       shop: shop_name,
@@ -73,10 +75,10 @@ class OrderWebhookJob < Job
     charity = Charity.find_by(shop: shop_name)
     donation_products = Product.where(shop: shop_name)
 
-    donations = donations_from_order(order, donation_products)
+    donations = donations_from_order(order, charity, donation_products)
     donation_amount = donations.sum
 
-    refunded_donations = donations_from_refund(order, donation_products)
+    refunded_donations = donations_from_refund(order, charity, donation_products)
     refunded_amount = refunded_donations.sum
 
     amount = donation_amount - refunded_amount
@@ -155,7 +157,7 @@ class OrderWebhookJob < Job
       .first
     end
 
-  def donations_from_order(order, donation_products)
+  def donations_from_order(order, charity, donation_products)
     donations = []
 
     order["line_items"].each do |item|
@@ -164,14 +166,17 @@ class OrderWebhookJob < Job
       end
 
       if donation_product
-        donations << item["price"].to_f * item["quantity"].to_i * (donation_product.percentage / 100.0)
+        price = item["price"].to_f
+        quantity = item["quantity"].to_i
+        total = price * quantity
+        donations << total * (donation_product.percentage / 100.0)
       end
     end
 
     donations
   end
 
-  def donations_from_refund(order, donation_products)
+  def donations_from_refund(order, charity, donation_products)
     donations = []
 
     return donations unless order["refunds"].present?
@@ -185,7 +190,10 @@ class OrderWebhookJob < Job
         end
 
         if donation_product
-          donations << line_item["price"].to_f * refund_item["quantity"].to_i * (donation_product.percentage / 100.0)
+          price = line_item["price"].to_f
+          quantity = refund_item["quantity"].to_i
+          total = price * quantity
+          donations << total * (donation_product.percentage / 100.0)
         end
       end
     end

--- a/src/routes/charity.rb
+++ b/src/routes/charity.rb
@@ -37,6 +37,7 @@ class SinatraApp < Sinatra::Base
       'charity_id',
       'donation_id_prefix',
       'receipt_threshold',
+      'subtract_discounts',
       'email_from',
       'email_bcc',
       'email_subject',

--- a/test/fixtures/order_with_discount.json
+++ b/test/fixtures/order_with_discount.json
@@ -1,0 +1,166 @@
+{
+  "id": 1977641762904,
+  "email": "bob.norman@example.com",
+  "closed_at": null,
+  "created_at": "2019-12-17T08:43:41-05:00",
+  "updated_at": "2019-12-17T12:30:38-05:00",
+  "number": 4342,
+  "note": null,
+  "total_price": "79.28",
+  "subtotal_price": "70.00",
+  "total_weight": 164,
+  "total_tax": "0.00",
+  "taxes_included": false,
+  "currency": "CAD",
+  "financial_status": "paid",
+  "confirmed": true,
+  "total_discounts": "10.00",
+  "total_line_items_price": "80.00",
+  "cart_token": "",
+  "buyer_accepts_marketing": true,
+  "name": "#5332",
+  "referring_site": null,
+  "landing_site": "\/api\/2019-07\/graphql.json",
+  "cancelled_at": null,
+  "cancel_reason": null,
+  "total_price_usd": "60.22",
+  "checkout_token": "token",
+  "reference": null,
+  "user_id": null,
+  "location_id": null,
+  "source_identifier": null,
+  "source_url": null,
+  "processed_at": "2019-12-17T08:43:41-05:00",
+  "device_id": null,
+  "phone": null,
+  "order_number": 5332,
+  "discount_applications": [
+    {
+      "type": "automatic",
+      "value": "5.0",
+      "value_type": "fixed_amount",
+      "allocation_method": "each",
+      "target_selection": "entitled",
+      "target_type": "line_item",
+      "title": "Plush Bundle - Bulk Discount"
+    }
+  ],
+  "contact_email": "bob.norman@example.com",
+  "line_items": [
+    {
+      "variant_id": 32007568654424,
+      "title": "Grizzly Bear Adoption Kit - Plush Bundle",
+      "quantity": 2,
+      "sku": "",
+      "variant_title": "",
+      "vendor": "The Earth Rangers Shop",
+      "fulfillment_service": "manual",
+      "product_id": 4436552548440,
+      "requires_shipping": true,
+      "taxable": false,
+      "gift_card": false,
+      "name": "Grizzly Bear Adoption Kit - Plush Bundle",
+      "variant_inventory_management": "shopify",
+      "properties": [],
+      "product_exists": true,
+      "fulfillable_quantity": 0,
+      "grams": 82,
+      "price": "40.00",
+      "total_discount": "10.00",
+      "fulfillment_status": null,
+      "price_set": {
+        "shop_money": {
+          "amount": "40.00",
+          "currency_code": "CAD"
+        },
+        "presentment_money": {
+          "amount": "40.00",
+          "currency_code": "CAD"
+        }
+      },
+      "total_discount_set": {
+        "shop_money": {
+          "amount": "10.00",
+          "currency_code": "CAD"
+        },
+        "presentment_money": {
+          "amount": "10.00",
+          "currency_code": "CAD"
+        }
+      },
+      "discount_allocations": [
+        {
+          "amount": "10.00",
+          "discount_application_index": 0,
+          "amount_set": {
+            "shop_money": {
+              "amount": "10.00",
+              "currency_code": "CAD"
+            },
+            "presentment_money": {
+              "amount": "10.00",
+              "currency_code": "CAD"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "billing_address": {
+    "first_name": "Bob",
+    "address1": "Chestnut Street 92",
+    "phone": "",
+    "city": "Louisville",
+    "zip": "40202",
+    "province": "Kentucky",
+    "country": "United States",
+    "last_name": "Norman",
+    "address2": "",
+    "company": "",
+    "name": "Bob Norman",
+    "country_code": "US",
+    "province_code": "KY"
+  },
+  "shipping_address": {
+    "first_name": "Bob",
+    "address1": "Chestnut Street 92",
+    "phone": "",
+    "city": "Louisville",
+    "zip": "40202",
+    "province": "Kentucky",
+    "country": "United States",
+    "last_name": "Norman",
+    "address2": "",
+    "company": "",
+    "name": "Bob Norman",
+    "country_code": "US",
+    "province_code": "KY"
+  },
+  "customer": {
+    "email": "bob.normon@example.com",
+    "accepts_marketing": true,
+    "first_name": "Bob",
+    "last_name": "Norman",
+    "note": null,
+    "phone": null,
+    "tags": "",
+    "currency": "CAD",
+    "default_address": {
+      "first_name": "Bob",
+      "last_name": "Norman",
+      "company": "",
+      "address1": "Chestnut Street 92",
+      "address2": "",
+      "city": "Louisville",
+      "province": "Kentucky",
+      "country": "United States",
+      "zip": "40202",
+      "phone": "",
+      "name": "Bob Norman",
+      "province_code": "KY",
+      "country_code": "US",
+      "country_name": "United States",
+      "default": true
+    }
+  }
+}

--- a/views/_charity.erb
+++ b/views/_charity.erb
@@ -61,6 +61,15 @@
       <span class="help-block">Only send receipts for donations greater than a certain amount</span>
     </div>
 
+    <div class="checkbox">
+      <label for="subtract_discounts">
+        <input type="hidden" name="subtract_discounts" value="false">
+        <input type="checkbox" name="subtract_discounts" value="true" <%= "checked" if charity.present? && charity.subtract_discounts %>>
+        <strong>Subtract Discounts</strong>
+      </label>
+      <span class="help-block">If checked then the app will subtract discounts on the order from the donation</span>
+    </div>
+
     <div class="form-group">
       <input type="submit" class="btn btn-primary pull-right" value="save">
     </div>


### PR DESCRIPTION
Adds a setting to have the app subtract discounts from the donation amount.

![image](https://user-images.githubusercontent.com/1965489/71785826-5b529d80-2fd2-11ea-98f1-b1b72b3203ba.png)

With the box ticked the `total_discount` amount for a line item is subtracted from the `total` before the donation percentage is applied.