### PR TITLE
use discount allocations

### DIFF
--- a/src/jobs/order_webhook_job.rb
+++ b/src/jobs/order_webhook_job.rb
@@ -171,8 +171,10 @@ class OrderWebhookJob < Job
 
         total = price * quantity
 
-        if charity.subtract_discounts
-          total -= item["total_discount"].to_f
+        if charity.subtract_discounts && item["discount_allocations"].present?
+          item["discount_allocations"].each do |discount|
+            total -= discount["amount"].to_f
+          end
         end
 
         donations << total * (donation_product.percentage / 100.0)
@@ -201,8 +203,10 @@ class OrderWebhookJob < Job
 
           total = price * quantity
 
-          if charity.subtract_discounts
-            total -= line_item["total_discount"].to_f
+          if charity.subtract_discounts && line_item["discount_allocations"].present?
+            line_item["discount_allocations"].each do |discount|
+              total -= discount["amount"].to_f
+            end
           end
 
           donations << total * (donation_product.percentage / 100.0)


### PR DESCRIPTION
It seems Shopify does not always set `total_discount` and discount_allocations are a better way to get the discount applied to a line item.

This field is an empty array when there are no discounts (the code is safe here regardless).