### PR TITLE
configure api version with a constant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.6.3'
 gem 'rake'
 gem 'foreman'
 
-gem 'shopify-sinatra-app', '~> 0.9.0'
+gem 'shopify-sinatra-app', '~> 0.10.0'
 gem 'sinatra-contrib'
 gem 'activerecord', '5.2.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     redis (4.1.3)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.1)
-    shopify-sinatra-app (0.9.0)
+    shopify-sinatra-app (0.10.0)
       activesupport
       attr_encrypted (~> 3.1.0)
       browser_sniffer (~> 1.1.3)
@@ -213,7 +213,7 @@ DEPENDENCIES
   rack-test
   rake
   redis
-  shopify-sinatra-app (~> 0.9.0)
+  shopify-sinatra-app (~> 0.10.0)
   sidekiq
   sinatra-contrib
   sqlite3

--- a/playbook.md
+++ b/playbook.md
@@ -59,7 +59,7 @@ Check webhooks for shop:
 name = 'kevintest3.myshopify.com'
 shop = Shop.find_by(name: name)
 
-api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: '2019-04')
+api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: API_VERSION)
 ShopifyAPI::Base.activate_session(api_session)
 
 ShopifyAPI::Webhook.all

--- a/playbook.md
+++ b/playbook.md
@@ -14,9 +14,8 @@ SIDEKIQ_USERNAME=
 SIDEKIQ_PASSWORD=
 DEVELOPMENT=1
 
-Install `forward` with `gem install forward`
-Make sure the tunnel is started `./ngrok http 5000`
-Then configure your Shopify API Client to use the ngrok url.
+Then start ngrok `./ngrok http 5000`
+Configure the Shopify API Client and the `base_url` in `AfterInstallJob` to use the ngrok url.
 
 Then run `foreman start -m all=1,release=0 ` or `PORT=5000 foreman run web` if you need byebug
 

--- a/src/app.rb
+++ b/src/app.rb
@@ -25,8 +25,12 @@ require_relative 'routes/charity'
 require_relative 'routes/products'
 require_relative 'routes/gdpr'
 
+API_VERSION = "2019-04"
+
 class SinatraApp < Sinatra::Base
   register Sinatra::Shopify
+
+  set :api_version, API_VERSION
   set :scope, 'read_products, read_orders, read_all_orders'
 
   register Kaminari::Helpers::SinatraHelpers

--- a/src/jobs/after_install_job.rb
+++ b/src/jobs/after_install_job.rb
@@ -20,7 +20,7 @@ class AfterInstallJob < Job
 
   def base_url
     if ENV['DEVELOPMENT']
-      'https://shopify-kevinhughes27.fwd.wf'
+      'https://75ea1c1c.ngrok.io'
     elsif ENV['STAGING']
       'https://taxreceipts-staging.herokuapp.com'
     else

--- a/src/jobs/job.rb
+++ b/src/jobs/job.rb
@@ -3,7 +3,7 @@ class Job
 
   def activate_shopify_api(shop_name)
     shop = Shop.find_by(name: shop_name)
-    api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: '2019-04')
+    api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: API_VERSION)
     ShopifyAPI::Base.activate_session(api_session)
   end
 end

--- a/src/models/donation.rb
+++ b/src/models/donation.rb
@@ -128,7 +128,7 @@ class Donation < ActiveRecord::Base
 
   def with_shopify_api
     shop = Shop.find_by(name: self.shop)
-    ShopifyAPI::Session.temp(domain: shop.name, token: shop.token, api_version: '2019-04') do
+    ShopifyAPI::Session.temp(domain: shop.name, token: shop.token, api_version: API_VERSION) do
       yield
     end
   end

--- a/src/tasks/announcement.rake
+++ b/src/tasks/announcement.rake
@@ -5,7 +5,7 @@ end
 def send_announcement(shop)
   puts "Sending announcement to shop: #{shop.name}"
 
-  api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: '2019-04')
+  api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: API_VERSION)
   ShopifyAPI::Base.activate_session(api_session)
 
   shopify_shop = ShopifyAPI::Shop.current

--- a/src/tasks/debug.rake
+++ b/src/tasks/debug.rake
@@ -5,7 +5,7 @@ require 'irb'
 
 task :debug_shop, [:shop] do |t, args|
   shop = Shop.find_by(name: args[:shop])
-  api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: '2019-04')
+  api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: API_VERSION)
   ShopifyAPI::Base.activate_session(api_session)
 
   ARGV.clear # otherwise all script parameters get passed to IRB

--- a/src/tasks/webhooks.rake
+++ b/src/tasks/webhooks.rake
@@ -1,6 +1,3 @@
-require 'sidekiq'
-require_relative '../../src/jobs/after_install_job'
-
 task :recreate_webhooks do
   Shop.find_each { |shop| recreate_webhooks(shop) }
 end
@@ -12,7 +9,7 @@ end
 def recreate_webhooks(shop)
   puts "shop: #{shop.name}"
 
-  api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: '2019-04')
+  api_session = ShopifyAPI::Session.new(domain: shop.name, token: shop.token, api_version: API_VERSION)
   ShopifyAPI::Base.activate_session(api_session)
 
   ShopifyAPI::Shop.current

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -2,20 +2,20 @@ module Helpers
   include Rack::Test::Methods
 
   def activate_shopify_session(shop, token)
-    session = ShopifyAPI::Session.new(domain: shop, token: token, api_version: '2019-04')
+    session = ShopifyAPI::Session.new(domain: shop, token: token, api_version: API_VERSION)
     ShopifyAPI::Base.activate_session session
   end
 
   def mock_shop_api_call
-    fake "https://apple.myshopify.com/admin/api/2019-04/shop.json", :body => load_fixture('shop.json')
+    fake "https://apple.myshopify.com/admin/api/#{API_VERSION}/shop.json", :body => load_fixture('shop.json')
   end
 
   def mock_order_api_call(order_id)
-    fake "https://apple.myshopify.com/admin/api/2019-04/orders/#{order_id}.json", :body => load_fixture('order.json')
+    fake "https://apple.myshopify.com/admin/api/#{API_VERSION}/orders/#{order_id}.json", :body => load_fixture('order.json')
   end
 
   def mock_product_api_call(product_id)
-    fake "https://apple.myshopify.com/admin/api/2019-04/products/#{product_id}.json", :body => load_fixture('product.json')
+    fake "https://apple.myshopify.com/admin/api/#{API_VERSION}/products/#{product_id}.json", :body => load_fixture('product.json')
   end
 
   def fake(url, options={})


### PR DESCRIPTION
shopify-sinatra-app now supports setting an api version. This app involves sidekiq and setting up api sessions in a few other ways so I set a new constant for the api version which can be used everywhere and passed into shopify-sinatra-app.

ToDo
- [x] :tophat: 