### PR TITLE
Update shopify-sinatra-app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ updates:
   - dependency-name: activerecord
     versions:
     - "> 5.2.3"
-  - dependency-name: omniauth
-    versions:
-    - 2.0.1
   - dependency-name: pry
     versions:
     - 0.13.1

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rake'
 gem 'puma'
 
 gem 'sinatra'
-gem 'shopify-sinatra-app', '~> 0.12.0'
+gem 'shopify-sinatra-app', path: '../shopify-sinatra-app'
 gem 'sinatra-flash'
 gem 'sinatra-contrib'
 gem 'activerecord', '5.2.3'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rake'
 gem 'puma'
 
 gem 'sinatra'
-gem 'shopify-sinatra-app', path: '../shopify-sinatra-app'
+gem 'shopify-sinatra-app', '~> 1.0.0'
 gem 'sinatra-flash'
 gem 'sinatra-contrib'
 gem 'activerecord', '5.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,18 @@ GIT
       padrino-helpers
       sinatra
 
+PATH
+  remote: ../shopify-sinatra-app
+  specs:
+    shopify-sinatra-app (1.0.0)
+      activesupport
+      attr_encrypted (~> 3.1.0)
+      omniauth (>= 2.0.4)
+      omniauth-shopify-oauth2 (>= 2.3.2)
+      shopify_api (>= 7.0.1, < 9.3.0)
+      sinatra (~> 2.0.2)
+      sinatra-activerecord (~> 2.0.9)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -62,12 +74,20 @@ GEM
     encryptor (3.0.0)
     erubi (1.8.0)
     fakeweb (1.3.0)
-    faraday (1.3.0)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
-    graphql (1.12.4)
+    faraday-net_http_persistent (1.1.0)
+    graphql (1.12.12)
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)
@@ -75,7 +95,7 @@ GEM
     hashie (4.1.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jwt (2.2.2)
+    jwt (2.2.3)
     kaminari-activerecord (1.2.1)
       activerecord
       kaminari-core (= 1.2.1)
@@ -104,15 +124,16 @@ GEM
     nokogiri (1.11.4)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    oauth2 (1.4.4)
+    oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.9.1)
+    omniauth (2.0.4)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
+      rack-protection
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
@@ -156,14 +177,6 @@ GEM
     redis (4.3.1)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.4)
-    shopify-sinatra-app (0.12.0)
-      activesupport
-      attr_encrypted (~> 3.1.0)
-      omniauth (= 1.9.1)
-      omniauth-shopify-oauth2 (>= 2.3.2)
-      shopify_api (>= 7.0.1, < 9.3.0)
-      sinatra (~> 2.0.2)
-      sinatra-activerecord (~> 2.0.9)
     shopify_api (9.2.0)
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
@@ -178,7 +191,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    sinatra-activerecord (2.0.22)
+    sinatra-activerecord (2.0.23)
       activerecord (>= 4.1)
       sinatra (>= 1.0)
     sinatra-contrib (2.0.8.1)
@@ -223,7 +236,7 @@ DEPENDENCIES
   rack-test
   rake
   redis
-  shopify-sinatra-app (~> 0.12.0)
+  shopify-sinatra-app!
   sidekiq
   sinatra
   sinatra-contrib

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,18 +9,6 @@ GIT
       padrino-helpers
       sinatra
 
-PATH
-  remote: ../shopify-sinatra-app
-  specs:
-    shopify-sinatra-app (1.0.0)
-      activesupport
-      attr_encrypted (~> 3.1.0)
-      omniauth (>= 2.0.4)
-      omniauth-shopify-oauth2 (>= 2.3.2)
-      shopify_api (>= 7.0.1, < 9.3.0)
-      sinatra (~> 2.0.2)
-      sinatra-activerecord (~> 2.0.9)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -177,7 +165,15 @@ GEM
     redis (4.3.1)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.4)
-    shopify_api (9.2.0)
+    shopify-sinatra-app (1.0.0)
+      activesupport
+      attr_encrypted (~> 3.1.0)
+      omniauth (>= 2.0.4)
+      omniauth-shopify-oauth2 (>= 2.3.2)
+      shopify_api (>= 7.0.1, < 9.4.0)
+      sinatra (>= 2.0.2, < 2.2.0)
+      sinatra-activerecord (~> 2.0.9)
+    shopify_api (9.3.0)
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
@@ -236,7 +232,7 @@ DEPENDENCIES
   rack-test
   rake
   redis
-  shopify-sinatra-app!
+  shopify-sinatra-app (~> 1.0.0)
   sidekiq
   sinatra
   sinatra-contrib

--- a/src/app.rb
+++ b/src/app.rb
@@ -22,10 +22,6 @@ require_relative 'jobs/uninstall_job'
 require_relative 'utils/email_service'
 require_relative 'utils/render_pdf'
 
-require_relative 'routes/charity'
-require_relative 'routes/products'
-require_relative 'routes/gdpr'
-
 API_VERSION = "2021-04"
 
 class SinatraApp < Sinatra::Base
@@ -33,6 +29,10 @@ class SinatraApp < Sinatra::Base
 
   register Sinatra::Shopify
   register Sinatra::Flash
+
+  require_relative 'routes/charity'
+  require_relative 'routes/products'
+  require_relative 'routes/gdpr'
 
   set :api_version, API_VERSION
   set :scope, 'read_products, read_orders, read_all_orders'
@@ -104,17 +104,13 @@ class SinatraApp < Sinatra::Base
   end
 
   # receive uninstall webhook
-  post '/uninstall' do
-    shopify_webhook do |shop_name, params|
-      UninstallJob.perform_async(shop_name)
-    end
+  shopify_webhook('/uninstall') do |shop_name, params|
+    UninstallJob.perform_async(shop_name)
   end
 
   # orders/updated webhook receiver
-  post '/order' do
-    shopify_webhook do |shop_name, order|
-      OrderWebhookJob.perform_async(shop_name, order)
-    end
+  shopify_webhook('/order') do |shop_name, order|
+    OrderWebhookJob.perform_async(shop_name, order)
   end
 
   # view a donation receipt pdf

--- a/src/routes/products.rb
+++ b/src/routes/products.rb
@@ -34,10 +34,8 @@ class SinatraApp < Sinatra::Base
   end
 
   # products/update webhook receiver
-  post '/product_update' do
-    shopify_webhook do |shop_name, product|
-      ProductWebhookJob.perform_async(shop_name, product)
-    end
+  shopify_webhook('/product_update') do |shop_name, product|
+    ProductWebhookJob.perform_async(shop_name, product)
   end
 
   # delete product (stops getting a donation receipt)

--- a/views/_charity.erb
+++ b/views/_charity.erb
@@ -1,5 +1,7 @@
 <div class="well" style="padding-bottom: 50px;">
   <form method="POST" action="/charity" role="form" style="max-width: 320px;">
+    <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
+
     <% if charity.present? %>
       <input type="hidden" name="_method" value="put" />
     <% end %>

--- a/views/_donations.erb
+++ b/views/_donations.erb
@@ -49,6 +49,7 @@
 
           <td style="width:1px;">
             <form method="POST" action="/resend">
+              <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
               <input type="hidden" name="id" value="<%= donation.id %>" />
               <input
                 type="submit"
@@ -60,6 +61,7 @@
 
           <td style="width:1px;">
             <form method="POST" action="/void">
+              <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
               <input type="hidden" name="id" value="<%= donation.id %>" />
               <input
                 type="submit"

--- a/views/_products.erb
+++ b/views/_products.erb
@@ -39,6 +39,7 @@
           </td>
 
           <form method="POST" action="/products">
+            <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
             <input type="hidden" name="_method" value="put" />
             <input type="hidden" name="id" value="<%= product.id %>" />
 
@@ -62,6 +63,7 @@
 
           <td style="width:1px;">
             <form method="POST" action="/products">
+              <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
               <input type="hidden" name="_method" value="delete" />
               <input type="hidden" name="id" value="<%= product.id %>" />
               <input type="submit" class="btn btn-danger align-right" value="delete">

--- a/views/components/_email_modals.erb
+++ b/views/components/_email_modals.erb
@@ -38,6 +38,7 @@
       </div>
 
       <form method="POST" action="/charity" role="form">
+        <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
         <input type="hidden" name="_method" value="put" />
 
         <div class="modal-body">
@@ -150,6 +151,7 @@
       </div>
 
       <form method="POST" action="/charity" role="form">
+        <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
         <input type="hidden" name="_method" value="put" />
 
         <div class="modal-body">

--- a/views/components/_export_donations.erb
+++ b/views/components/_export_donations.erb
@@ -8,8 +8,9 @@
       </div>
 
       <form method="POST" action="/export" role="form">
-        <div class="modal-body">
+        <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
 
+        <div class="modal-body">
           <div class="form-group">
             <label for="email_to">Email</label>
             <input type="text" class="form-control" name="email_to" value="<%= shop.email %>" style="width: 97%"/>

--- a/views/components/_pdf_modal.erb
+++ b/views/components/_pdf_modal.erb
@@ -27,6 +27,7 @@
       <div class="modal-footer">
         <div class="pull-left">
           <form method="POST" action="/preview_pdf" target="_blank" role="form">
+            <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
             <input type="hidden" name="template" value="<%= charity.pdf_template %>" bind="pdfTemplate" />
             <input type="hidden" name="status" value="default" bind="previewOptions" />
             <button type="submit" class="btn btn-default">Preview</button>
@@ -34,6 +35,7 @@
         </div>
 
         <form method="POST" action="/charity" role="form">
+          <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
           <input type="hidden" name="_method" value="put" />
           <input type="hidden" name="pdf_template" value="<%= charity.pdf_template %>" bind="pdfTemplate" />
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/views/components/_product_email_modal.erb
+++ b/views/components/_product_email_modal.erb
@@ -38,6 +38,7 @@
       </div>
 
       <form method="POST" action="/products/<%= product.id %>" role="form">
+        <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
         <input type="hidden" name="_method" value="put" />
 
         <div class="modal-body">
@@ -154,6 +155,7 @@
       </div>
 
       <form method="POST" action="/products" role="form">
+        <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
         <input type="hidden" name="_method" value="put" />
         <input type="hidden" name="id" value="<%= product.id %>" />
 

--- a/views/login.erb
+++ b/views/login.erb
@@ -24,13 +24,26 @@
   <div style="margin-top: 30px"></div>
 
   <div class="container">
-    <form role="form" class="form-large" action="/login" method="post">
+    <form id="login" role="form" class="form-large" action="/auth/shopify" method="post">
+      <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
       <div class="input-group form-wide">
-        <input class="form-control" type="url" name="shop" placeholder="Shop URL">
+        <input class="form-control" name="shop" value="<%= params['shop'] %>" placeholder="your-shop-url.myshopify.com">
         <span class="input-group-btn">
-          <input class="btn" type="submit" value="Install App" />
+          <input class="btn" type="submit" value="Login" />
         </span>
       </div>
     </form>
   </div>
+
+  <% if params['shop'].present? %>
+    <div style="position: fixed; top: 0; left: 0; height: 100%; width: 100%; z-index: 1000; background: white;">
+      <div style="padding-left: 10px; padding-top: 10px">
+        Logging in...
+      </div>
+    </div>
+
+    <script>
+      document.getElementById("login").submit();
+    </script>
+  <% end %>
 </body>

--- a/views/webhooks.erb
+++ b/views/webhooks.erb
@@ -29,6 +29,7 @@
         <td><%= webhook.address %></td>
         <td>
           <form method="POST" action="/webhooks">
+            <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
             <input type="hidden" name="_method" value="delete" />
             <input type="hidden" name="id" value="<%= webhook.id %>" />
             <input type="submit" class="btn btn-default align-right" value="delete">


### PR DESCRIPTION
This update bumps omniauth to 2.0.4 which requires re-working the authentication flow to use posts (change in login.erb). It also adds rack protection which requires adding csrf tokens to forms. The `shopify_webhook` method has changed and it now defines the route as well as handling the webhook because the method also ignores the csrf token check for incoming webhooks.