### PR TITLE
Fix pdf preview

### DIFF
--- a/views/components/_pdf_modal.erb
+++ b/views/components/_pdf_modal.erb
@@ -26,7 +26,7 @@
 
       <div class="modal-footer">
         <div class="pull-left">
-          <form method="POST" action="/preview_pdf" target="_blank" role="form">
+          <form method="POST" action="/preview_pdf" role="form">
             <input type="hidden" name="authenticity_token" value="<%= env['rack.session'][:csrf] %>" />
             <input type="hidden" name="template" value="<%= charity.pdf_template %>" bind="pdfTemplate" />
             <input type="hidden" name="status" value="default" bind="previewOptions" />


### PR DESCRIPTION
I had to remove the `target=+blank` from preview pdf form because it was erroring with 403 forbidden. I am not sure exactly when this broken, it could have been the secure cookie changes or it could be changes in new browsers. Either way it doesn't seem like a great idea.

It does make the workflow less great though because preview doesn't save the template and now the preview is in the same tab and when you go back you've lost your place (the edit state is actually there but you have to go back to the form to save it).

The ideal solution would be to send the preview request via javascript and render the preview side by side with the editor.

I also noticed that the preview on the html emails breaks the modal scroll and buttons are hidden afterwards. Side by side previews would be a good addition there too. 