### PR TITLE
bump wkhtmltopdf and wicked_pdf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,14 +16,14 @@ gem 'kaminari-activerecord'
 gem 'sidekiq'
 gem 'redis'
 
-gem 'wicked_pdf'
+gem 'wicked_pdf', '~> 2.6.3'
 gem 'pony'
 gem 'liquid'
 gem 'bugsnag', '~> 6.22'
 
 group :production do
   gem 'pg'
-  gem 'wkhtmltopdf-heroku'
+  gem 'wkhtmltopdf-heroku', '2.12.6.0'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 
 group :development do
   gem 'sqlite3'
-  gem 'wkhtmltopdf-binary'
+  gem 'wkhtmltopdf-binary', '0.12.6.5'
   gem 'pdf-inspector'
   gem 'letter_opener'
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,10 +192,10 @@ GEM
     ttfunk (1.5.1)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
-    wicked_pdf (1.4.0)
+    wicked_pdf (2.6.3)
       activesupport
     wkhtmltopdf-binary (0.12.4)
-    wkhtmltopdf-heroku (2.12.5.0)
+    wkhtmltopdf-heroku (2.12.6.0)
 
 PLATFORMS
   ruby
@@ -225,9 +225,9 @@ DEPENDENCIES
   sinatra-contrib (~> 2.2.0)
   sinatra-flash
   sqlite3
-  wicked_pdf
+  wicked_pdf (~> 2.6.3)
   wkhtmltopdf-binary
-  wkhtmltopdf-heroku
+  wkhtmltopdf-heroku (= 2.12.6.0)
 
 RUBY VERSION
    ruby 2.6.6p146

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       thread_safe (~> 0.1)
     wicked_pdf (2.6.3)
       activesupport
-    wkhtmltopdf-binary (0.12.4)
+    wkhtmltopdf-binary (0.12.6.5)
     wkhtmltopdf-heroku (2.12.6.0)
 
 PLATFORMS
@@ -226,7 +226,7 @@ DEPENDENCIES
   sinatra-flash
   sqlite3
   wicked_pdf (~> 2.6.3)
-  wkhtmltopdf-binary
+  wkhtmltopdf-binary (= 0.12.6.5)
   wkhtmltopdf-heroku (= 2.12.6.0)
 
 RUBY VERSION

--- a/src/utils/render_pdf.rb
+++ b/src/utils/render_pdf.rb
@@ -1,26 +1,4 @@
 require 'tilt/liquid'
-
-# mock rails classes for wicked_pdf
-module Rails
-  def self.env
-    'production'
-  end
-
-  module VERSION
-    MAJOR = 0
-  end
-end
-
-class WickedPdf
-  class Mime
-    class Type
-      def self.lookup_by_extension(var)
-        true
-      end
-    end
-  end
-end
-
 require 'wicked_pdf'
 
 def render_pdf(shop, charity, donation)


### PR DESCRIPTION
wkhtmltopdf_heroku does have support for the next heroku stack. It will need to be updated when I bump the stack.

Tested on staging:
- [x] pdf preview with image
- [x] donation receipt pdf attachment with an image 