### PR TITLE
allow multiple emails in email_bcc

### DIFF
--- a/src/models/charity.rb
+++ b/src/models/charity.rb
@@ -1,10 +1,8 @@
 class Charity < ActiveRecord::Base
-  EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
-
   validates :shop, uniqueness: true
   validates_presence_of :name, :charity_id
   validates :receipt_threshold, numericality: { greater_than: 0 }, allow_nil: true
-  validates_format_of :email_bcc, with: EMAIL_REGEX, allow_blank: true
+  validate :validate_email_bcc
 
   def self.attr_or_default(attr, default)
     define_method(attr) do
@@ -35,5 +33,19 @@ class Charity < ActiveRecord::Base
       'charity_id' => charity_id,
       'donation_id_prefix' => donation_id_prefix
     }
+  end
+
+  private
+
+  def validate_email_bcc
+    return unless self.email_bcc
+
+    emails = self.email_bcc.split(",").map(&:strip)
+
+    emails.each do |email|
+      self.errors.add(:emails, "invalid email") unless email =~ URI::MailTo::EMAIL_REGEXP
+    end
+
+    self.email_bcc = emails.join(",")
   end
 end

--- a/test/charity_test.rb
+++ b/test/charity_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class CharityTest < ActiveSupport::TestCase
+  setup do
+    @shop = "apple.myshopify.com"
+    @charity = Charity.find_by(shop: @shop)
+  end
+
+  test "blank email_bcc" do
+    @charity.email_bcc = ""
+    assert @charity.save
+  end
+
+  test "valid email_bcc" do
+    @charity.email_bcc = "joe@example.com"
+    assert @charity.save
+  end
+
+  test "multiple email_bcc" do
+    @charity.email_bcc = "joe@example.com, bob@example.com"
+    assert @charity.save
+  end
+
+  test "invalid email_bcc" do
+    @charity.email_bcc = "example.com"
+    refute @charity.save
+  end
+end


### PR DESCRIPTION
the previous email regex only accepted a single email address. Now the function supports a comma separated list. Pony already support a comma separated list of emails to the `bcc` which is where this gets used https://github.com/benprew/pony/blob/master/spec/pony_spec.rb#L70