### PR TITLE
don't create a donation if the amount is 0 or less

### DIFF
--- a/src/jobs/order_webhook_job.rb
+++ b/src/jobs/order_webhook_job.rb
@@ -50,6 +50,8 @@ class OrderWebhookJob < Job
       donation_amount = include_tip(order, donation_amount)
     end
 
+    return if donation_amount <= 0
+
     donation = Donation.new(
       shop: shop_name,
       order: order.to_json,


### PR DESCRIPTION
This is possible with certain discount configurations. Before discounts were added the check on number of products was sufficient to guard this.